### PR TITLE
Issue #5: prompt and procedure refinements

### DIFF
--- a/docs/content/status.json
+++ b/docs/content/status.json
@@ -1,5 +1,64 @@
 {
-  "generatedAt": "2026-04-18T23:00:00Z",
-  "openIssueCount": 0,
-  "groups": []
+  "generatedAt": "2026-04-19T00:00:00Z",
+  "openIssueCount": 5,
+  "groups": [
+    {
+      "label": "Bugs",
+      "description": "Known issues affecting current behavior.",
+      "issues": [
+        {
+          "number": 3,
+          "title": "init: Routines prompts are not self-contained for remote CCR",
+          "summary": "Scheduled update and digest runs fail in the remote CCR environment because the emitted prompts assume the plugin is already installed.",
+          "url": "https://github.com/calumjs/docent/issues/3",
+          "updatedAt": "2026-04-19T00:54:34Z",
+          "labels": ["bug"]
+        }
+      ]
+    },
+    {
+      "label": "Enhancements",
+      "description": "Proposed additions and larger behavior changes.",
+      "issues": [
+        {
+          "number": 2,
+          "title": "init: backfill journal with dated posts from commit history",
+          "summary": "Partition a new install's git history into cadence buckets and produce one dated post per bucket so the journal arrives lived-in rather than empty.",
+          "url": "https://github.com/calumjs/docent/issues/2",
+          "updatedAt": "2026-04-19T00:55:24Z",
+          "labels": ["enhancement"]
+        },
+        {
+          "number": 4,
+          "title": "Add sourceCommit/sourceFiles frontmatter so update can detect stale content",
+          "summary": "Anchor generated files to the repo state that produced them so the update mode can tell what actually needs regenerating.",
+          "url": "https://github.com/calumjs/docent/issues/4",
+          "updatedAt": "2026-04-19T00:54:51Z",
+          "labels": ["enhancement"]
+        },
+        {
+          "number": 6,
+          "title": "Add a 'suggest' skill that files feedback as a GitHub issue",
+          "summary": "Structured intake that lets users file Docent feedback without leaving Claude Code — config and version attached, secrets redacted.",
+          "url": "https://github.com/calumjs/docent/issues/6",
+          "updatedAt": "2026-04-19T00:56:00Z",
+          "labels": ["enhancement"]
+        }
+      ]
+    },
+    {
+      "label": "Documentation",
+      "description": "Prompt wording, procedure steps, and schema notes that need tightening.",
+      "issues": [
+        {
+          "number": 5,
+          "title": "Prompt and procedure refinements found during init dogfooding",
+          "summary": "Four sub-items: inaugural-voice guidance, tone examples per content type, empty-state contract, harness-independent shell command in init Step 5.",
+          "url": "https://github.com/calumjs/docent/issues/5",
+          "updatedAt": "2026-04-19T00:55:11Z",
+          "labels": ["documentation"]
+        }
+      ]
+    }
+  ]
 }

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -104,8 +104,13 @@ Then generate `docs/package-lock.json` so the deploy workflow's
 `cache: npm` + `npm ci` don't fail on first push:
 
 ```bash
-cd docs && npm install --ignore-scripts && cd ..
+npm install --prefix docs --ignore-scripts
 ```
+
+Use `--prefix docs` rather than `cd docs && npm install && cd ..` —
+harnesses vary on whether cwd persists between bash calls, and any
+chain of `cd` instructions risks leaving the shell in `docs/` for the
+next step. `--prefix` is a single, cwd-independent invocation.
 
 `--ignore-scripts` avoids running postinstall hooks from template deps;
 we only need the lock file, not a functional install. The resulting
@@ -168,7 +173,14 @@ Create `docs/content/` and fill it:
 - Write a single "project so far" post summarizing the repo's history.
 - Use commit history, tags, and README to identify the project's origin and
   major milestones.
-- Tone should be welcoming — this is likely the first post a visitor reads.
+- Follow the **Inaugural and backfill posts** section of
+  `prompts/journal-system.md`, NOT the digest guidance. The inaugural
+  post spans the whole repo history, is retrospective rather than
+  contemporaneous, and has `mode: "init"` in its frontmatter so
+  scheduled runs treat it as immutable.
+- Tone should be welcoming — this is likely the first post a visitor
+  reads — but honest: frame it as reading the commit log, not as
+  reporting on work you were present for.
 
 ### Step 7.5 — Analyze the repo's design and write `theme.json`
 

--- a/skills/docent/prompts/journal-system.md
+++ b/skills/docent/prompts/journal-system.md
@@ -75,3 +75,45 @@ Good:
 Bad:
 > This week was a productive one! We made many great improvements across
 > the codebase.
+
+## Inaugural and backfill posts
+
+A journal post written during `init`, or any post produced by a
+future `backfill` mode, is NOT a weekly digest. Don't apply the
+digest-specific framing. Instead:
+
+- **Scope is wider** — a backfill post may cover months of commits
+  rather than a week. Themes should still be 2–5, but each one can
+  span longer and has more to draw on.
+- **Tone is welcoming** — for the *inaugural* (oldest) post,
+  specifically, assume the reader is first-time-ever. A returning
+  visitor reading a mid-archive backfill post doesn't need the same
+  warmth; match the tone preset's **Journal opening** style.
+- **Frontmatter differs**:
+  - `date` is the date of the last commit in the bucket, not today.
+  - `commitRange` is the first..last sha of the bucket.
+  - `mode` is `"init"` or `"backfill"`, not `"digest"`. This signals
+    to `update` mode that the post is immutable — later runs must not
+    regenerate it even if the underlying activity is re-analyzed.
+- **Honesty matters** — these posts are *retrospective reconstructions*
+  from the commit log, not contemporaneous reporting. Frame them that
+  way. Acceptable: "Looking at the commits from this period, …",
+  "The archive shows …", past tense throughout. Unacceptable:
+  "This week we decided to …" (you weren't there and didn't decide
+  anything), inventing motivations the commits don't record,
+  attributing feelings or intentions to contributors from commit
+  messages alone.
+- **No cliffhangers** — regular digests sometimes end with a "coming
+  up" paragraph. Backfill posts don't — there's no "coming up" in a
+  historical record. End with a neutral closer or none at all.
+
+A good inaugural opening (`neutral` tone, after install on a repo
+with months of prior history):
+
+> Looking back at the commit history so far, three arcs show up: the
+> initial API surface landed in January, auth was rewritten around
+> passkeys in February, and March was a long bug sweep.
+
+A bad one:
+
+> Welcome! This is the first post on our new journal.

--- a/skills/docent/prompts/status-system.md
+++ b/skills/docent/prompts/status-system.md
@@ -61,3 +61,30 @@ dropped at build time.
 Within each group, sort issues by `updatedAt` descending. This makes the
 status page feel current without being unstable — the same issues appear
 in the same order until their activity changes.
+
+## Empty state
+
+When there are zero open issues after filtering, do NOT emit an empty
+`groups` array. The page template renders empty arrays as a bare
+heading with no body, which reads as broken rather than calm. Emit a
+single synthesized group instead:
+
+```json
+{
+  "generatedAt": "...",
+  "openIssueCount": 0,
+  "groups": [
+    {
+      "label": "All clear",
+      "description": "No open issues right now. Issues opened on GitHub will appear here on the next update.",
+      "issues": []
+    }
+  ]
+}
+```
+
+This keeps the contract uniform — every rendered status page has at
+least one labeled section with prose a reader can understand — and
+means the template's loop over `groups[]` never special-cases empty.
+The description text should be tuned to the project's tone preset;
+the example above is `neutral`.

--- a/skills/docent/prompts/tone-presets.md
+++ b/skills/docent/prompts/tone-presets.md
@@ -3,21 +3,34 @@
 Docent supports four tones, configurable via `tone` in `docent.config.json`.
 Apply the matching guidance when writing any content.
 
+Each tone has two example openings, because **overview and journal
+voices differ**. The overview introduces *what the project is*; the
+journal reports *what happened this week*. Same tone, different
+structure. When picking a voice for a given content type, match the
+example for that type.
+
 ## `neutral` (default)
 
 Plain, descriptive, past tense for retrospective content. Minimal
 adjectives. No exclamation marks. Reads like competent documentation.
 
-Example opening: "The auth module was rewritten to support passkeys."
+- **Overview opening:** "Docent turns a GitHub repository into a
+  public-facing static website. It reads the repo's commits, issues,
+  and releases, and writes the site's content."
+- **Journal opening:** "The auth module was rewritten to support
+  passkeys. Three Safari bugs were closed alongside it."
 
 ## `formal`
 
-Third-person, publication-style. Slightly more elevated vocabulary. Longer
-sentences are OK if they're well-constructed. Suitable for projects that
-want to read like a company release or an academic tool.
+Third-person, publication-style. Slightly more elevated vocabulary.
+Longer sentences are OK if they're well-constructed. Suitable for
+projects that want to read like a company release or an academic tool.
 
-Example opening: "The authentication module has been substantially
-restructured to introduce native passkey support."
+- **Overview opening:** "Docent is a documentation system that produces
+  a public-facing static website from a project's own source history,
+  issue tracker, and release metadata."
+- **Journal opening:** "The authentication module has been substantially
+  restructured to introduce native passkey support."
 
 ## `playful`
 
@@ -26,18 +39,24 @@ admit mistakes openly ("we broke login for a full day on Tuesday and
 everyone was very annoyed"). Avoid forced jokes. Humor should come from
 specifics, not from the voice straining to be funny.
 
-Example opening: "We finally got passkeys working, only 11 months after
-saying we would."
+- **Overview opening:** "Docent is the little robot that reads your
+  repo and writes the website your repo wishes it had. We built it
+  because README.md is doing too much."
+- **Journal opening:** "We finally got passkeys working, only 11 months
+  after saying we would."
 
 ## `technical`
 
 Assume the reader is a developer. Include file paths, PR numbers inline
 (not just as links), module names. Short, dense sentences. Still
-accessible — this isn't a release notes dump, it's a readable summary
-for someone who cares about implementation.
+accessible — the overview isn't a README and the journal isn't a
+release-notes dump, but both assume technical fluency.
 
-Example opening: "`src/auth/` was rewritten around the WebAuthn API.
-Session cookies are gone; tokens now live in IndexedDB."
+- **Overview opening:** "Docent is a Claude Code skill (`skills/docent/`)
+  that writes MDX and JSON into `/docs/content/` and ships an Astro
+  template that renders it. Deploys via GitHub Pages."
+- **Journal opening:** "`src/auth/` was rewritten around the WebAuthn
+  API. Session cookies are gone; tokens now live in IndexedDB."
 
 ## Common rules (all tones)
 
@@ -45,3 +64,11 @@ Session cookies are gone; tokens now live in IndexedDB."
 - No "simply," "just," or "easily" describing features.
 - No superlatives without support. "Fastest" requires a benchmark link.
 - No fictional testimonials or user quotes.
+
+## How to apply
+
+When the overview prompt asks for the opening paragraph, consult the
+**Overview opening** for the active tone. When the journal prompt asks
+for the opening, consult the **Journal opening**. Don't cross the
+streams — a journal that opens like an overview feels stale, and an
+overview that opens like a journal confuses first-time visitors.


### PR DESCRIPTION
Closes #5. Four sub-items.

## 1. Inaugural/backfill voice

`prompts/journal-system.md` has a new section explaining that posts generated during `init` (and future `backfill`) are **retrospective reconstructions**, not weekly digests. Covers: wider scope, welcoming-but-honest framing, frontmatter differences (mode, date, commitRange), and a "no cliffhangers" rule. `init.md` Step 7 now points at it explicitly.

## 2. Tone examples per content type

`prompts/tone-presets.md` now gives each of the four tones two example openings: one **Overview opening** and one **Journal opening**. Resolves the bleed where the technical tone's lone example was journal-voiced but got pulled into overview generation.

## 3. Empty-state contract for status.json

`prompts/status-system.md` specifies that zero-open-issue repos emit a synthesized \"All clear\" group with prose, not ` groups: []`. Template needs no change — the contract is uniform across populated and empty cases.

The live `docs/content/status.json` was updated in the same commit to reflect the 5 currently open issues, which also exercises the populated-state rendering.

## 4. Harness-independent Step 5

`init.md` Step 5 switched from `cd docs && npm install && cd ..` to `npm install --prefix docs` so it works in harnesses that persist cwd across bash calls.

## Verification

`npm run build --prefix docs` passes. All 7 pages generate, including `/status/` with the new 5-issue grouped rendering.