### PR TITLE
Issue #3: self-contained Routines prompts

### DIFF
--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -241,13 +241,26 @@ This PR scaffolds a Docent-maintained site at `/docs`.
      ```
 2. **Merge this PR.** The deploy workflow runs automatically.
 3. **Set up the Routines** that keep content fresh. In any Claude Code
-   session, run:
+   session, run these two commands. Each spawns a remote environment
+   that starts with *nothing installed* — the prompts must bootstrap
+   the Docent plugin before dispatching to the mode:
+
    ```
-   /schedule update Docent daily at 10:17 — prompt: "Docent: run update mode."
-   /schedule digest Docent weekly on Mondays at 9:17 — prompt: "Docent: run digest mode."
+   /schedule Docent update daily at 10:17 — If the Docent skill is not available in this environment, run `/plugin marketplace add calumjs/docent` and `/plugin install docent@docent` first. Then follow skills/docent/modes/update.md against the current repo.
    ```
-   Or configure them at claude.ai/code/routines. Routines use your Claude
-   Code subscription — no `ANTHROPIC_API_KEY` required.
+
+   ```
+   /schedule Docent digest weekly on Mondays at 9:17 — If the Docent skill is not available in this environment, run `/plugin marketplace add calumjs/docent` and `/plugin install docent@docent` first. Then follow skills/docent/modes/digest.md against the current repo.
+   ```
+
+   The bootstrap clause is there because Claude Code Routines run in a
+   clean remote CCR environment that does NOT inherit plugins from the
+   maintainer's local session — without it, the first scheduled run
+   fails silently and the site quietly goes stale.
+
+   Or configure the routines at claude.ai/code/routines directly,
+   including the same bootstrap text in each prompt. Routines use your
+   Claude Code subscription — no `ANTHROPIC_API_KEY` required.
 
 The site will be live at {{homepage}} shortly after the first deploy.
 EOF
@@ -256,10 +269,43 @@ EOF
 
 ### Step 10 — Report back to the user
 
-Report the PR URL and echo the three-step checklist from the PR body. Make
-the two `/schedule` commands the most prominent part of the reply —
-they're the step the user most often forgets. Call out that Routines run
-on their subscription plan, not via a separate API key.
+Report the PR URL and echo the three-step checklist from the PR body.
+Make the two routine-creation commands the most prominent part of the
+reply — they're the step the user most often forgets. Call out that
+Routines run on their subscription plan, not via a separate API key.
+
+**Offer to create the routines directly.** At the end of the report,
+ask whether the user wants you to set up the two routines now. If they
+agree, invoke the `schedule` skill (via the Skill tool) with the two
+routine definitions below. This saves the user from pasting the long
+bootstrap prompts manually.
+
+The two routine definitions to pass:
+
+1. Name: `Docent update`. Cron: daily at 10:17 local (convert to UTC
+   for the cron expression based on the user's timezone). Prompt:
+   ```
+   If the Docent skill is not available in this environment, run:
+     /plugin marketplace add calumjs/docent
+     /plugin install docent@docent
+   Then follow skills/docent/modes/update.md against this repo. Open
+   a PR against the default branch if anything changed.
+   ```
+
+2. Name: `Docent digest`. Cron: Mondays at 9:17 local (convert to UTC).
+   Prompt:
+   ```
+   If the Docent skill is not available in this environment, run:
+     /plugin marketplace add calumjs/docent
+     /plugin install docent@docent
+   Then follow skills/docent/modes/digest.md against this repo. Open
+   a PR against the default branch with the new journal post.
+   ```
+
+Both routines target the user's GitHub repo (owner/repo already
+collected in Step 1). If the user declines the offer or the schedule
+skill isn't available, fall back to printing the paste-these commands
+from Step 9's PR body.
 
 ## Exit conditions
 

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -262,6 +262,26 @@ This PR scaffolds a Docent-maintained site at `/docs`.
    including the same bootstrap text in each prompt. Routines use your
    Claude Code subscription — no `ANTHROPIC_API_KEY` required.
 
+   **Trust / pinning note.** `docent@docent` tracks the marketplace's
+   default ref (the Docent repo's `master`). Every routine run pulls
+   the latest version, which is the same trust posture as any
+   auto-updating tool. Users who want stricter reproducibility can pin
+   to a specific commit by replacing the install line with
+   `/plugin install docent@docent@<commit-sha>` (e.g. a tagged
+   release). Pinning trades update freshness for supply-chain
+   tightness — if the Docent repo is ever compromised, pinned
+   installs keep running the known-good version.
+
+   **DST caveat.** Claude Code Routines take UTC cron only; they do
+   not currently support IANA-timezone-aware scheduling. A routine
+   scheduled for "10:17 Sydney" becomes a fixed UTC cron that drifts
+   by an hour when Australia enters or leaves AEDT. For most content
+   workflows this doesn't matter (who cares if the daily update runs
+   at 09:17 vs 10:17?), but users who need wall-clock-stable timing
+   should plan to re-adjust the cron twice yearly at DST transitions,
+   or pick a local time far from midnight where an hour's drift is
+   inconsequential.
+
 The site will be live at {{homepage}} shortly after the first deploy.
 EOF
 )"


### PR DESCRIPTION
Closes #3.

## Problem

`modes/init.md` Step 9 emits paste-these `/schedule` commands for the user:

```
/schedule update Docent daily at 10:17 — prompt: \"Docent: run update mode.\"
```

Those prompts assume the Docent plugin is installed in the remote CCR the trigger spawns into. It isn't — CCR starts with a clean env, no marketplaces, no plugins. First scheduled run fails silently; site goes stale; maintainer never knows until they check.

## Fix

### Step 9 — Bootstrap-then-dispatch prompts

New prompts include an \"if missing, install\" clause and then dispatch by reading the mode file from the cloned repo checkout:

```
If the Docent skill is not available in this environment, run:
  /plugin marketplace add calumjs/docent
  /plugin install docent@docent

Then follow skills/docent/modes/update.md against this repo.
```

Relies on the cloned-repo files as the source of truth for mode procedures, which works regardless of whether the plugin resolves — belt and suspenders.

### Step 10 — Offer to create routines directly

At the end of init, the skill now offers to invoke the `schedule` skill with the two routine definitions inline (cron, name, full bootstrap prompt). If the user accepts, no paste required. Falls back to the paste-these commands if they decline or `schedule` isn't available.

### Live triggers on calumjs/docent

Both existing triggers (`trig_01YbVXQWnhXkScwVhfr4mcZj` update, `trig_01Xzx4aT8Zo4Ew9KHEZ4SUxV` digest) were updated via `RemoteTrigger update` with the new prompt pattern so tomorrow's scheduled runs don't still hit the broken prompt from yesterday's manual setup.

## Acceptance

- [x] Step 9 emits prompts that install the plugin if missing, then dispatch
- [x] PR body explains the bootstrap clause and why it exists
- [x] Stretch: Step 10 offers to create triggers via the schedule skill directly