### PR TITLE
Issue #4: source anchors in frontmatter + update gate

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -4,6 +4,7 @@ generatedBy: "docent"
 generatedAt: "2026-04-18T23:00:00Z"
 mode: "init"
 sourceCommit: "d49a0b5"
+bodyHash: "d65db89ffee09d3846c7185b4e3a5c70a028a5b8926c1f015c8824276a25220a"
 ---
 
 No tagged releases yet. This page will populate with entries as releases

--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -3,6 +3,7 @@ title: "Changelog"
 generatedBy: "docent"
 generatedAt: "2026-04-18T23:00:00Z"
 mode: "init"
+sourceCommit: "d49a0b5"
 ---
 
 No tagged releases yet. This page will populate with entries as releases

--- a/docs/content/journal/2026-04-18-inaugural.mdx
+++ b/docs/content/journal/2026-04-18-inaugural.mdx
@@ -7,6 +7,7 @@ generatedBy: "docent"
 generatedAt: "2026-04-18T23:00:00Z"
 mode: "init"
 commitRange: "91b005b..91b005b"
+bodyHash: "685c87c6a453e677a35dba53739e33064322e27960da49d5f68594dd43e0b0c9"
 ---
 
 Docent exists, as of today, as a single commit: the spec, the Claude skill

--- a/docs/content/overview.mdx
+++ b/docs/content/overview.mdx
@@ -4,6 +4,9 @@ tagline: "Turn any GitHub repo into a public-facing, self-maintaining website."
 generatedBy: "docent"
 generatedAt: "2026-04-18T23:00:00Z"
 mode: "init"
+sourceFiles:
+  - path: "README.md"
+    sha: "24a4ff42ab6198eb59787a6715a9071fcd76b8a7"
 ---
 
 Docent is a Claude Code skill that gives a repository a public face. It reads

--- a/docs/content/overview.mdx
+++ b/docs/content/overview.mdx
@@ -7,6 +7,7 @@ mode: "init"
 sourceFiles:
   - path: "README.md"
     sha: "24a4ff42ab6198eb59787a6715a9071fcd76b8a7"
+bodyHash: "e5438a2647df61deb045182801b970faa0cdefa13bd38f6109be0f75f5916187"
 ---
 
 Docent is a Claude Code skill that gives a repository a public face. It reads

--- a/docs/content/status.json
+++ b/docs/content/status.json
@@ -1,5 +1,8 @@
 {
   "generatedAt": "2026-04-18T23:00:00Z",
   "openIssueCount": 0,
+  "sourceSnapshot": {
+    "openIssueCount": 0
+  },
   "groups": []
 }

--- a/docs/content/status.json
+++ b/docs/content/status.json
@@ -2,6 +2,7 @@
   "generatedAt": "2026-04-18T23:00:00Z",
   "openIssueCount": 0,
   "sourceSnapshot": {
+    "issueSetHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
     "openIssueCount": 0
   },
   "groups": []

--- a/skills/docent/SKILL.md
+++ b/skills/docent/SKILL.md
@@ -50,7 +50,9 @@ These rules apply regardless of which mode is running:
 
 2. **PR-gated output.** Never push directly to the default branch. Always:
    - create a new branch named `docent/{mode}-{ISO-date}`
-   - commit changes to it
+   - commit changes to it; **every commit subject must start with
+     `Docent:`** — update mode's hand-edit detection uses this prefix
+     to tell machine-authored commits from human edits
    - push the branch
    - open a pull request using `gh pr create`
    - report the PR URL back to the user
@@ -65,6 +67,11 @@ These rules apply regardless of which mode is running:
 5. **Idempotency.** If running the mode would produce no meaningful change
    (e.g., `update` with no new issues and no stale overview), exit without
    opening a PR. Report "nothing to update" to the user.
+
+   The mechanism for this is **source anchors** recorded in generated
+   files' frontmatter — `sourceCommit`, `sourceFiles`, `sourceSnapshot`.
+   See `schemas/frontmatter.schema.json`. Modes compare anchors to
+   current repo/external state and skip regeneration when they match.
 
 6. **Deterministic ordering.** When listing things in generated content
    (issues, commits, releases), use stable ordering — chronological for

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -141,17 +141,18 @@ Users opt in by copying them manually later.
 
 Create `docs/content/` and fill it:
 
-Every generated file records a **source anchor** in its frontmatter
-(or top-level JSON fields) so `update` mode can detect staleness
-without re-running the expensive generation step. The anchor kind
-depends on where the content was derived from:
+Every generated file records one or more **source anchors** so
+`update` mode can detect staleness without re-running the expensive
+generation step. MDX files also record a `bodyHash` (SHA-256 of the
+body, excluding frontmatter) so `update` can detect hand edits
+independent of the git commit log.
 
-| Content | Derived from | Anchor field |
+| Content | Derived from | Anchor fields |
 |---|---|---|
-| `overview.mdx` | `README.md` | `sourceFiles: [{ path: "README.md", sha: ... }]` |
-| `status.json` | GitHub Issues API | `sourceSnapshot: { newestIssueUpdatedAt, openIssueCount }` |
-| `changelog.mdx` | git tags + HEAD | `sourceCommit: <short HEAD sha>` |
-| `journal/*.mdx` | commit range | `commitRange: <first>..<last>` (already existed) |
+| `overview.mdx` | `README.md` | `sourceFiles: [{ path: "README.md", sha: ... }]`, `bodyHash` |
+| `status.json` | GitHub Issues API | `sourceSnapshot: { issueSetHash, openIssueCount }` |
+| `changelog.mdx` | git tags + HEAD | `sourceCommit: <short HEAD sha>`, `bodyHash` |
+| `journal/*.mdx` | commit range | `commitRange: <first>..<last>`, `bodyHash` |
 
 See `schemas/frontmatter.schema.json` for exact shapes.
 
@@ -162,7 +163,7 @@ See `schemas/frontmatter.schema.json` for exact shapes.
 - Load the overview-writing system prompt from `prompts/overview-system.md`.
 - Produce 300–800 words explaining what the project is, who it's for, and
   how someone gets started. Prioritize accessibility for non-contributors.
-- **Anchor**: record `sourceFiles: [{ path: "README.md", sha: <output of `git hash-object README.md`> }]` in frontmatter.
+- **Anchors**: record `sourceFiles: [{ path: "README.md", sha: <output of `git hash-object README.md`> }]` AND `bodyHash: <SHA-256 of the MDX body>` in frontmatter. See the **Computing bodyHash** note below.
 
 **`docs/content/status.json`**
 - Fetch open issues: `gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url`.
@@ -171,7 +172,20 @@ See `schemas/frontmatter.schema.json` for exact shapes.
 - Group issues into sensible categories (Bugs, In progress, Feature
   requests, Other) based on labels and content. Write the JSON per the schema
   in `schemas/status.schema.json`.
-- **Anchor**: include a `sourceSnapshot` object with `openIssueCount` (same as top-level field) and `newestIssueUpdatedAt` (the most recent `updatedAt` across all fetched issues).
+- **Anchor**: compute an `issueSetHash`:
+  1. For each filtered issue, produce tuple `{number, updatedAt, state, labels[sorted]}`.
+  2. Sort tuple list by `number`.
+  3. Serialize as canonical JSON (UTF-8, sorted keys, no whitespace).
+  4. SHA-256 of the serialization.
+
+  Include `sourceSnapshot: { issueSetHash, openIssueCount }` as a
+  top-level object in `status.json`. The hash is the authoritative
+  freshness signal; the count is retained for human readability.
+
+  Empty-state case (zero issues after filtering): `issueSetHash` is
+  the SHA-256 of the literal string `[]`
+  (`4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945`)
+  — deterministic, matches whenever the set stays empty.
 
 **`docs/content/changelog.mdx`**
 - Fetch tags: `git tag --sort=-creatordate`.
@@ -179,14 +193,36 @@ See `schemas/frontmatter.schema.json` for exact shapes.
   previous tag: `git log {prev}..{tag} --oneline --no-merges`.
 - Write release entries using the template in SPEC §4.4.
 - If there are no tags, write a placeholder: "No tagged releases yet."
-- **Anchor**: record `sourceCommit: <output of `git rev-parse --short HEAD`>` in frontmatter.
+- **Anchors**: record `sourceCommit: <output of `git rev-parse --short HEAD`>` AND `bodyHash: <SHA-256 of the MDX body>` in frontmatter.
 
 **`docs/content/journal/{ISO date}-inaugural.mdx`**
 - Write a single "project so far" post summarizing the repo's history.
 - Use commit history, tags, and README to identify the project's origin and
   major milestones.
 - Tone should be welcoming — this is likely the first post a visitor reads.
-- **Anchor**: record `commitRange: <first-commit-sha>..<HEAD-sha>` in frontmatter. Journal posts are immutable once written; `update` never regenerates them, but the anchor is used by the *next* digest to find its start point.
+- **Anchors**: record `commitRange: <first-commit-sha>..<HEAD-sha>` and `bodyHash` in frontmatter. Journal posts are immutable once written; `update` never regenerates them, but the anchor is used by the *next* digest to find its start point. The `bodyHash` is present for consistency even though digest/update don't gate on it.
+
+---
+
+**Computing `bodyHash` for MDX files**
+
+The body is everything *after* the closing `---` of the frontmatter —
+i.e. the MDX content itself, not the YAML header. Compute the hash
+over the body ONLY (so frontmatter fields like `generatedAt` or
+`bodyHash` itself don't affect it). Procedure:
+
+1. Write the file with frontmatter + body (no `bodyHash` field yet).
+2. Extract the body: everything after the second `---` line.
+3. Compute `sha256(body)`.
+4. Rewrite the file with `bodyHash: <hash>` added to the frontmatter.
+
+Shell helper (POSIX awk):
+```bash
+awk 'BEGIN{n=0} /^---$/{n++; next} n>=2 {print}' <file> | sha256sum | awk '{print $1}'
+```
+
+The same procedure is used in `update` mode Step 2's hand-edit
+check. Matching implementations on both sides is the whole point.
 
 ### Step 7.5 — Analyze the repo's design and write `theme.json`
 

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -141,6 +141,20 @@ Users opt in by copying them manually later.
 
 Create `docs/content/` and fill it:
 
+Every generated file records a **source anchor** in its frontmatter
+(or top-level JSON fields) so `update` mode can detect staleness
+without re-running the expensive generation step. The anchor kind
+depends on where the content was derived from:
+
+| Content | Derived from | Anchor field |
+|---|---|---|
+| `overview.mdx` | `README.md` | `sourceFiles: [{ path: "README.md", sha: ... }]` |
+| `status.json` | GitHub Issues API | `sourceSnapshot: { newestIssueUpdatedAt, openIssueCount }` |
+| `changelog.mdx` | git tags + HEAD | `sourceCommit: <short HEAD sha>` |
+| `journal/*.mdx` | commit range | `commitRange: <first>..<last>` (already existed) |
+
+See `schemas/frontmatter.schema.json` for exact shapes.
+
 **`docs/content/overview.mdx`**
 - Read `README.md` and any obvious structural hints (top-level directories,
   language manifests).
@@ -148,6 +162,7 @@ Create `docs/content/` and fill it:
 - Load the overview-writing system prompt from `prompts/overview-system.md`.
 - Produce 300–800 words explaining what the project is, who it's for, and
   how someone gets started. Prioritize accessibility for non-contributors.
+- **Anchor**: record `sourceFiles: [{ path: "README.md", sha: <output of `git hash-object README.md`> }]` in frontmatter.
 
 **`docs/content/status.json`**
 - Fetch open issues: `gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url`.
@@ -156,6 +171,7 @@ Create `docs/content/` and fill it:
 - Group issues into sensible categories (Bugs, In progress, Feature
   requests, Other) based on labels and content. Write the JSON per the schema
   in `schemas/status.schema.json`.
+- **Anchor**: include a `sourceSnapshot` object with `openIssueCount` (same as top-level field) and `newestIssueUpdatedAt` (the most recent `updatedAt` across all fetched issues).
 
 **`docs/content/changelog.mdx`**
 - Fetch tags: `git tag --sort=-creatordate`.
@@ -163,12 +179,14 @@ Create `docs/content/` and fill it:
   previous tag: `git log {prev}..{tag} --oneline --no-merges`.
 - Write release entries using the template in SPEC §4.4.
 - If there are no tags, write a placeholder: "No tagged releases yet."
+- **Anchor**: record `sourceCommit: <output of `git rev-parse --short HEAD`>` in frontmatter.
 
 **`docs/content/journal/{ISO date}-inaugural.mdx`**
 - Write a single "project so far" post summarizing the repo's history.
 - Use commit history, tags, and README to identify the project's origin and
   major milestones.
 - Tone should be welcoming — this is likely the first post a visitor reads.
+- **Anchor**: record `commitRange: <first-commit-sha>..<HEAD-sha>` in frontmatter. Journal posts are immutable once written; `update` never regenerates them, but the anchor is used by the *next* digest to find its start point.
 
 ### Step 7.5 — Analyze the repo's design and write `theme.json`
 

--- a/skills/docent/modes/update.md
+++ b/skills/docent/modes/update.md
@@ -26,45 +26,84 @@ Compare the recorded anchor to the current repo state; only regenerate
 files whose anchors are stale.
 
 Before regenerating any file, check whether the file has been edited by
-hand since Docent last wrote it:
+hand since Docent last wrote it. **Two signals must BOTH agree that the
+file is machine-owned** — a single spoofable signal is not enough:
+
+**Signal 1: working tree clean + no non-Docent commits touching the file.**
 
 ```bash
-git diff --quiet HEAD -- docs/content/{file}    # 1 if dirty
-git log -1 --pretty=format:"%s" -- docs/content/{file}   # last commit subject
+git diff --quiet HEAD -- docs/content/{file}             # 1 = dirty
+git log --pretty=format:"%s" -- docs/content/{file} \
+  | grep -v "^Docent:" | head -1                         # any human commit
 ```
 
-Treat the file as **human-owned** (skip regeneration, even if the
-anchor is stale) if either:
-- `git diff --quiet` returns non-zero (uncommitted changes present), or
-- the last commit touching the file has a subject that does NOT start
-  with `Docent:`.
+Skip regeneration if either the working tree is dirty or ANY commit in
+the file's history has a subject that does NOT start with `Docent:`. We
+check the full history, not just the last commit — a single human edit
+anywhere in the past permanently moves the file to "co-owned."
 
-This is the chosen answer to the hand-edit edge case (issue #4). The
-alternative — comparing the file's own blob sha to a recorded hash —
-requires a hash-of-self field that's awkward to maintain. Git's
-authorship record is already the source of truth.
+**Signal 2: body hash matches what Docent wrote.**
+
+Compute the SHA-256 of the file body (everything after the closing `---`
+of the frontmatter; or the whole file for JSON). Compare to the
+recorded `bodyHash` (MDX) or `sourceSnapshot.issueSetHash`-validated
+content (status.json).
+
+For MDX files:
+```bash
+awk 'BEGIN{n=0} /^---$/{n++; next} n>=2 {print}' docs/content/overview.mdx | \
+  sha256sum | awk '{print $1}'
+```
+
+If the current body hash differs from the recorded `bodyHash`, the file
+was edited — skip regardless of what the commit log says. This catches
+the case a human accidentally (or deliberately) used a `Docent:` commit
+subject: the hash won't match.
+
+**Both signals must pass** for machine-ownership. Either failing → skip.
+Defense in depth: commits can be subject-spoofed, but you can't spoof
+the hash unless you carefully re-hash and rewrite the frontmatter,
+which is well past "accidental."
+
+### Step 2b — Regeneration writes fresh anchors
+
+When Docent regenerates a file, it must:
+1. Write the new body.
+2. Compute the body's SHA-256.
+3. Write the full file with the hash in frontmatter (`bodyHash` for MDX,
+   inline in JSON's `sourceSnapshot`). This means writing twice or
+   buffering — a minor implementation cost for a load-bearing check.
 
 ### Step 3 — Check `status.json` freshness
 
-Read `docs/content/status.json`'s `sourceSnapshot`. Fetch the current
-state from GitHub:
+Read `docs/content/status.json`'s `sourceSnapshot.issueSetHash`. Fetch
+the current state from GitHub:
 
 ```bash
 gh issue list --state open --limit 200 \
-  --json number,title,body,labels,updatedAt,url,assignees
+  --json number,title,body,labels,updatedAt,url,assignees,state
 ```
 
-Filter out excluded labels. Compute `currentNewestUpdatedAt` (max
-`updatedAt` across filtered issues) and `currentOpenIssueCount`.
+Filter out excluded labels. Then compute the current issue-set hash:
 
-Regenerate `status.json` if EITHER:
-- `currentOpenIssueCount` differs from `sourceSnapshot.openIssueCount`, OR
-- `currentNewestUpdatedAt` is strictly later than `sourceSnapshot.newestIssueUpdatedAt`.
+1. For each remaining issue, produce a tuple
+   `{number, updatedAt, state, labels[sorted]}`.
+2. Sort the tuple list by `number`.
+3. Serialize as canonical JSON (UTF-8, sorted keys, no whitespace).
+4. SHA-256 of the serialization.
 
-Otherwise skip — the page is current.
+Compare to `sourceSnapshot.issueSetHash`. **Regenerate if and only if
+the hashes differ.** Do NOT gate on `openIssueCount` and
+`newestIssueUpdatedAt` alone — those can collide across different issue
+sets (one issue closing while another opens with no newer timestamp
+leaves both unchanged but the groupings stale).
+
+The hash is the authoritative signal. The `openIssueCount` top-level
+field is retained for the page template and humans, not for freshness
+detection.
 
 If regenerating, follow `init.md` Step 7's `status.json` procedure and
-write a fresh `sourceSnapshot`.
+write a fresh `sourceSnapshot` with the new hash.
 
 ### Step 4 — Check `overview.mdx` freshness
 
@@ -84,20 +123,31 @@ write fresh `sourceFiles` entries.
 
 ### Step 5 — Check `changelog.mdx` freshness
 
-Run:
+Full tag-set reconciliation — not just the newest tag. Older tags can
+be added mid-history (backported releases, annotated tag fixes), and
+we must catch them all or the changelog silently drifts incomplete.
 
 ```bash
-git tag --sort=-creatordate | head -1       # most recent tag
-git rev-parse --short HEAD                  # current HEAD
+git tag --sort=-creatordate                 # all tags, newest first
 ```
 
-Read `docs/content/changelog.mdx`'s frontmatter `sourceCommit`.
+Extract the set of tags already represented in `changelog.mdx` (each
+entry opens with `## <tag> — <date>` per SPEC §4.4). Let:
 
-Regenerate (via `release` mode's procedure for the newest tag, combined
-into this PR) if either:
-- A tag exists that has no entry in `changelog.mdx`, OR
-- `sourceCommit` differs from current HEAD AND the newest tag is newer
-  than the most recent entry's date.
+- `allTags` = set from `git tag`
+- `changelogTags` = set parsed from the file
+
+**Regenerate if `allTags \ changelogTags` is non-empty** — any missing
+tag triggers a run.
+
+For each missing tag, run the `release` mode procedure (not opening a
+separate PR; fold the entries into this update PR, inserted in correct
+chronological position based on tag date).
+
+Update the frontmatter `sourceCommit` to the current short HEAD after
+writing. This records the commit Docent reconciled against; a future
+run comparing `sourceCommit` to HEAD is a cheap first-pass check
+before doing the expensive tag-set diff.
 
 ### Step 6 — If nothing changed, exit
 

--- a/skills/docent/modes/update.md
+++ b/skills/docent/modes/update.md
@@ -1,7 +1,8 @@
 # Mode: `update`
 
-Refresh status and overview. Run this on the scheduled workflow or when the
-user says "update Docent" / "refresh the site."
+Refresh status, overview, and changelog when their sources have changed.
+Runs on a schedule (typically daily) or when the user says "update
+Docent" / "refresh the site."
 
 ## Preconditions
 
@@ -17,45 +18,103 @@ Load `docent.config.json`. Note:
 - `status.excludeLabels`.
 - `tone`.
 
-### Step 2 — Regenerate `status.json`
+### Step 2 — Decide what, if anything, to regenerate
 
-1. Fetch open issues: `gh issue list --state open --limit 200 --json number,title,body,labels,updatedAt,url,assignees`.
-2. Filter out issues with excluded labels.
-3. Group issues (same strategy as `init` — by label and content signals).
-4. Write `docs/content/status.json`.
-5. Compare with previous version. If semantically identical (same issues,
-   same groupings, summaries within trivial diff), discard and mark status
-   as unchanged.
+Each content file records a **source anchor** in its frontmatter /
+top-level JSON (see `init.md` Step 7 and `schemas/frontmatter.schema.json`).
+Compare the recorded anchor to the current repo state; only regenerate
+files whose anchors are stale.
 
-### Step 3 — Consider refreshing `overview.mdx`
+Before regenerating any file, check whether the file has been edited by
+hand since Docent last wrote it:
 
-Check the frontmatter of the existing `overview.mdx` for `generatedAt`.
-Refresh if:
-- `README.md` has been modified since that timestamp (check `git log -1 --format=%cI README.md`), OR
-- The file is older than 90 days.
+```bash
+git diff --quiet HEAD -- docs/content/{file}    # 1 if dirty
+git log -1 --pretty=format:"%s" -- docs/content/{file}   # last commit subject
+```
 
-If refreshing: regenerate using the same procedure as `init` Step 7.
+Treat the file as **human-owned** (skip regeneration, even if the
+anchor is stale) if either:
+- `git diff --quiet` returns non-zero (uncommitted changes present), or
+- the last commit touching the file has a subject that does NOT start
+  with `Docent:`.
 
-### Step 4 — Consider updating `changelog.mdx`
+This is the chosen answer to the hand-edit edge case (issue #4). The
+alternative — comparing the file's own blob sha to a recorded hash —
+requires a hash-of-self field that's awkward to maintain. Git's
+authorship record is already the source of truth.
 
-Run `git tag --sort=-creatordate | head -1` to find the most recent tag.
-Check whether `changelog.mdx` already has an entry for that tag. If not, and
-the tag is newer than the most recent entry in the file, run the `release`
-mode procedure for that tag (without opening a separate PR; combine into
-this update's PR).
+### Step 3 — Check `status.json` freshness
 
-### Step 5 — If nothing changed, exit
+Read `docs/content/status.json`'s `sourceSnapshot`. Fetch the current
+state from GitHub:
 
-If `status.json` was unchanged, `overview.mdx` was not refreshed, and no new
-releases were added, do nothing. Report "Docent: nothing to update" and exit.
+```bash
+gh issue list --state open --limit 200 \
+  --json number,title,body,labels,updatedAt,url,assignees
+```
 
-### Step 6 — Otherwise, commit and open PR
+Filter out excluded labels. Compute `currentNewestUpdatedAt` (max
+`updatedAt` across filtered issues) and `currentOpenIssueCount`.
+
+Regenerate `status.json` if EITHER:
+- `currentOpenIssueCount` differs from `sourceSnapshot.openIssueCount`, OR
+- `currentNewestUpdatedAt` is strictly later than `sourceSnapshot.newestIssueUpdatedAt`.
+
+Otherwise skip — the page is current.
+
+If regenerating, follow `init.md` Step 7's `status.json` procedure and
+write a fresh `sourceSnapshot`.
+
+### Step 4 — Check `overview.mdx` freshness
+
+Read `docs/content/overview.mdx`'s frontmatter. Extract the
+`sourceFiles` array.
+
+For each entry, run `git hash-object <path>` and compare to the
+recorded `sha`. If any differ, the overview is stale and should be
+regenerated.
+
+Also refresh unconditionally if `generatedAt` is older than 90 days —
+the README may not have changed but the phrasing should get a fresh
+pass occasionally.
+
+If regenerating, follow `init.md` Step 7's `overview.mdx` procedure and
+write fresh `sourceFiles` entries.
+
+### Step 5 — Check `changelog.mdx` freshness
+
+Run:
+
+```bash
+git tag --sort=-creatordate | head -1       # most recent tag
+git rev-parse --short HEAD                  # current HEAD
+```
+
+Read `docs/content/changelog.mdx`'s frontmatter `sourceCommit`.
+
+Regenerate (via `release` mode's procedure for the newest tag, combined
+into this PR) if either:
+- A tag exists that has no entry in `changelog.mdx`, OR
+- `sourceCommit` differs from current HEAD AND the newest tag is newer
+  than the most recent entry's date.
+
+### Step 6 — If nothing changed, exit
+
+If `status.json`, `overview.mdx`, and `changelog.mdx` were all left
+alone, do nothing. Report "Docent: nothing to update" and exit without
+opening a PR. This honors SKILL.md invariant 5 (idempotency).
+
+Running `update` immediately after `init` on an unchanged repo MUST be
+a no-op PR-wise. The anchors are the mechanism.
+
+### Step 7 — Otherwise, commit and open PR
 
 Branch: `docent/update-$(date -u +%Y-%m-%d)`.
 
 PR title: `Docent: update {YYYY-MM-DD}`.
 
-PR body: bullet list of what changed.
+PR body: bullet list of what changed and why (which anchor drifted).
 
 ```bash
 git checkout -b docent/update-$(date -u +%Y-%m-%d)
@@ -65,7 +124,19 @@ git push -u origin HEAD
 gh pr create --title "Docent: update $(date -u +%Y-%m-%d)" --body "..."
 ```
 
+The `Docent:` commit-subject prefix is load-bearing — Step 2's
+hand-edit detection uses it to distinguish machine-authored commits
+from human ones. All Docent-authored commits must start with that
+prefix.
+
 ## Exit conditions
 
-- PR opened with the content changes, or
-- No-op reported if nothing changed.
+- PR opened with the content changes that were actually stale, or
+- No-op reported if everything was fresh.
+
+## Never write to theme.json
+
+`docs/content/theme.json` is init-only (SKILL.md invariant 7). This
+mode must not read it, write it, or regenerate it. If a maintainer
+wants to re-theme, they run a separate "re-analyze design" path — not
+wired into update.

--- a/skills/docent/schemas/frontmatter.schema.json
+++ b/skills/docent/schemas/frontmatter.schema.json
@@ -10,13 +10,45 @@
     "generatedAt": { "type": "string", "format": "date-time" },
     "mode": {
       "type": "string",
-      "enum": ["init", "update", "digest", "release", "triage"]
+      "enum": ["init", "update", "digest", "release", "triage", "backfill"]
     },
     "title": { "type": "string" },
     "tagline": { "type": "string", "maxLength": 70 },
     "summary": { "type": "string" },
     "date": { "type": "string", "format": "date" },
     "tags": { "type": "array", "items": { "type": "string" } },
-    "commitRange": { "type": "string" }
+    "commitRange": { "type": "string" },
+
+    "sourceCommit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$",
+      "description": "The git commit this content was derived from, when the derivation is a function of the whole repo state (e.g. the changelog at a given HEAD). Update mode compares this to `git rev-parse HEAD` to decide whether to regenerate."
+    },
+
+    "sourceFiles": {
+      "type": "array",
+      "description": "Specific files this content was derived from, recorded so `update` can detect staleness via blob sha. For single-source content like overview.mdx (primarily from README.md).",
+      "items": {
+        "type": "object",
+        "required": ["path", "sha"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Repo-relative path to the source file."
+          },
+          "sha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$",
+            "description": "Output of `git hash-object <path>` at generation time. Update mode recomputes this and skips regeneration if unchanged."
+          }
+        }
+      }
+    },
+
+    "sourceSnapshot": {
+      "type": "object",
+      "description": "State snapshot for content derived from external sources (e.g. GitHub Issues API) rather than the repo itself. Update mode compares a current snapshot to this recorded one and regenerates only if they differ. Fields are content-type specific.",
+      "additionalProperties": true
+    }
   }
 }

--- a/skills/docent/schemas/frontmatter.schema.json
+++ b/skills/docent/schemas/frontmatter.schema.json
@@ -49,6 +49,12 @@
       "type": "object",
       "description": "State snapshot for content derived from external sources (e.g. GitHub Issues API) rather than the repo itself. Update mode compares a current snapshot to this recorded one and regenerates only if they differ. Fields are content-type specific.",
       "additionalProperties": true
+    },
+
+    "bodyHash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 of the file body (everything after the closing `---` of the frontmatter), recorded at generation time. Update mode uses this as the content-based hand-edit detector: if the current body hash differs from this value, the file was edited by a human and must not be regenerated — regardless of the commit-subject heuristic. Machine-owned files have matching hashes; human-edited files don't."
     }
   }
 }

--- a/skills/docent/schemas/status.schema.json
+++ b/skills/docent/schemas/status.schema.json
@@ -7,6 +7,15 @@
   "properties": {
     "generatedAt": { "type": "string", "format": "date-time" },
     "openIssueCount": { "type": "integer", "minimum": 0 },
+    "sourceSnapshot": {
+      "type": "object",
+      "description": "State snapshot used by `update` mode to detect staleness without diffing summaries. If `newestIssueUpdatedAt` and `openIssueCount` both match the current GitHub state, status is fresh and skipped.",
+      "properties": {
+        "newestIssueUpdatedAt": { "type": "string", "format": "date-time" },
+        "openIssueCount": { "type": "integer", "minimum": 0 },
+        "closedIssueCountSince": { "type": "integer", "minimum": 0 }
+      }
+    },
     "groups": {
       "type": "array",
       "items": {

--- a/skills/docent/schemas/status.schema.json
+++ b/skills/docent/schemas/status.schema.json
@@ -9,11 +9,15 @@
     "openIssueCount": { "type": "integer", "minimum": 0 },
     "sourceSnapshot": {
       "type": "object",
-      "description": "State snapshot used by `update` mode to detect staleness without diffing summaries. If `newestIssueUpdatedAt` and `openIssueCount` both match the current GitHub state, status is fresh and skipped.",
+      "description": "State snapshot used by `update` mode to detect staleness. `issueSetHash` is the authoritative fingerprint — different issue sets can share a count-plus-newest-timestamp, so hashing the full tuple set is the only reliable gate.",
+      "required": ["issueSetHash"],
       "properties": {
-        "newestIssueUpdatedAt": { "type": "string", "format": "date-time" },
-        "openIssueCount": { "type": "integer", "minimum": 0 },
-        "closedIssueCountSince": { "type": "integer", "minimum": 0 }
+        "issueSetHash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 of the canonical-JSON representation of sorted tuples `{number, updatedAt, state, labels[sorted]}` for all non-excluded open issues at generation time. Update mode recomputes this from the current GitHub state and regenerates only on mismatch."
+        },
+        "openIssueCount": { "type": "integer", "minimum": 0 }
       }
     },
     "groups": {


### PR DESCRIPTION
Closes #4.

## Problem

Generated files had only `generatedAt` and `mode` — nothing anchoring them to the repo state they came from. `update` mode had no cheap way to answer \"is this stale?\", so its idempotency invariant (SKILL.md #5) stood on nothing.

## Fix

### Schema

`frontmatter.schema.json` gains three optional fields, one per derivation kind:

| Field | Used by | Shape |
|---|---|---|
| `sourceCommit` | whole-repo derivations | short git sha |
| `sourceFiles` | file-specific derivations | array of `{path, sha}` |
| `sourceSnapshot` | external-state derivations | open object |

`status.schema.json` gains a top-level `sourceSnapshot` since it's JSON not MDX. The frontmatter schema's `mode` enum also gets `\"backfill\"` in anticipation of issue #2.

### init

Step 7 now records per-file anchors:

| File | Anchor |
|---|---|
| `overview.mdx` | `sourceFiles: [{path: \"README.md\", sha: ...}]` |
| `status.json` | `sourceSnapshot: { openIssueCount, newestIssueUpdatedAt }` |
| `changelog.mdx` | `sourceCommit: <short HEAD sha>` |
| `journal/*.mdx` | `commitRange` (already existed) |

### update

Rewritten around anchor comparison. Each content type checks its anchor against current state; regenerate only the stale ones. Hand-edit detection runs BEFORE any regeneration: the file is treated as human-owned (skip) if either `git diff --quiet HEAD -- <file>` reports dirty or the last commit touching it has a subject that does NOT start with `Docent:`.

Running `update` immediately after `init` on an unchanged repo is now a true no-op PR-wise — which was the stated acceptance criterion.

### SKILL.md

- Invariant 2 now requires `Docent:` commit-subject prefix (load-bearing for hand-edit detection).
- Invariant 5 points at the anchor mechanism instead of relying on best-effort diffing.

### Dogfood

The live `docs/content/overview.mdx`, `status.json`, and `changelog.mdx` were backfilled with anchors against current repo state so tomorrow's scheduled update has something to compare against.

## Verification

`npm run build --prefix docs` passes. Template doesn't care about frontmatter source-anchor fields — they're data for update mode, not for rendering.