### PR TITLE
Issue #2: backfill journal with dated posts

### DIFF
--- a/docent.config.json
+++ b/docent.config.json
@@ -18,7 +18,9 @@
   "journal": {
     "cadence": "weekly",
     "announceReleases": true,
-    "minCommitsPerPost": 3
+    "minCommitsPerPost": 3,
+    "backfill": true,
+    "backfillLimit": 12
   },
   "status": {
     "groupStrategy": "auto",

--- a/skills/docent/SKILL.md
+++ b/skills/docent/SKILL.md
@@ -76,6 +76,13 @@ These rules apply regardless of which mode is running:
    runs. A maintainer who wants to re-theme invokes the analysis step
    explicitly ("Docent, re-analyze the design").
 
+8. **Journal posts are immutable once written.** Posts under
+   `docs/content/journal/*.mdx` are append-only regardless of their
+   `mode` (`init`, `backfill`, or `digest`). Scheduled runs never
+   rewrite existing posts — `digest` only adds new ones, `update`
+   doesn't touch journal at all. A maintainer who wants to correct a
+   post edits it by hand; Docent will respect the edit.
+
 ## Configuration
 
 Read `docent.config.json` at the repo root. Schema is defined in

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -80,7 +80,9 @@ Default contents:
   "journal": {
     "cadence": "{{chosen cadence}}",
     "announceReleases": true,
-    "minCommitsPerPost": 3
+    "minCommitsPerPost": 3,
+    "backfill": true,
+    "backfillLimit": 12
   },
   "status": {
     "groupStrategy": "auto",
@@ -164,11 +166,66 @@ Create `docs/content/` and fill it:
 - Write release entries using the template in SPEC §4.4.
 - If there are no tags, write a placeholder: "No tagged releases yet."
 
-**`docs/content/journal/{ISO date}-inaugural.mdx`**
-- Write a single "project so far" post summarizing the repo's history.
-- Use commit history, tags, and README to identify the project's origin and
-  major milestones.
-- Tone should be welcoming — this is likely the first post a visitor reads.
+**`docs/content/journal/*.mdx` — backfill posts**
+
+Journal generation branches on `journal.backfill` in config. Default
+is `true` (partition history); `false` writes a single inaugural.
+
+**If `journal.backfill === true`** (default):
+
+1. **Walk history chronologically**:
+   ```bash
+   git log --reverse --no-merges --format='%H|%aI|%s'
+   ```
+2. **Bucket commits by cadence** (from `journal.cadence`):
+   - `weekly`: week starts Monday 00:00 in the author's timezone (use
+     commit's `%aI` date). Group commits by ISO week.
+   - `biweekly`: every other Monday; pair adjacent weeks.
+   - `monthly`: first of month.
+   - `manual`: fall back to `weekly` for bucketing; the cadence field
+     only governs scheduled digests, not backfill.
+3. **Drop buckets with fewer than `journal.minCommitsPerPost` commits**
+   — no "quiet week" filler for dead periods.
+4. **Apply the cap**. If more than `journal.backfillLimit` buckets
+   remain, keep the most recent `backfillLimit - 1` buckets as
+   individual posts and collapse all older buckets into one "Early
+   history" roundup post (date = last commit of the oldest kept
+   bucket minus one second, so it sorts first chronologically).
+5. **For each kept bucket**, generate one post:
+   - Filename: `{YYYY-MM-DD}-{slug}.mdx` where date is the bucket's
+     last commit date and slug is kebab-case derived from the post's
+     headline (the model picks a headline; see
+     `prompts/journal-system.md` §Inaugural-and-backfill).
+   - Frontmatter:
+     ```yaml
+     date: "{last-commit-date}"
+     mode: "backfill"
+     commitRange: "{first-sha}..{last-sha}"
+     generatedBy: "docent"
+     generatedAt: "{ISO timestamp}"
+     ```
+   - Apply the **Inaugural and backfill posts** section of
+     `prompts/journal-system.md`. These posts are retrospective
+     reconstructions, not contemporaneous reporting — frame them
+     honestly ("Looking at the commits from this period, …").
+   - The oldest backfill post implicitly opens the archive; do NOT
+     also write a separate welcome/inaugural post.
+
+**If `journal.backfill === false`**:
+
+Write a single `docs/content/journal/{YYYY-MM-DD}-inaugural.mdx` using
+the "project so far" approach — whole-repo-history scope, welcoming
+first-visitor voice, `mode: "init"`, `commitRange: {first-sha}..{HEAD-sha}`.
+
+**Why a cap matters**: cost scales linearly with bucket count. A
+5-year repo on weekly cadence is 260 Claude calls uncapped. With
+`backfillLimit: 12` it's 13 calls regardless of repo age.
+
+**Honesty with history**: force-pushed or rebased commits produce
+timestamps that don't reflect when work actually happened. Don't try
+to work around this; just note it in the init PR body so the
+maintainer knows the backfilled dates are git-authoritative, not
+memory-authoritative.
 
 ### Step 7.5 — Analyze the repo's design and write `theme.json`
 
@@ -230,7 +287,16 @@ This PR scaffolds a Docent-maintained site at `/docs`.
 - Overview page based on this repo's README and structure
 - Status page summarizing {{N}} open issues
 - Changelog with {{N}} release entries
-- Inaugural journal post
+- **{{N}} backfill journal posts** covering the repo's history
+  ({{bucket description}}):
+  {{each filename on its own line, oldest first}}
+
+> **About the backfill posts**: these are **retrospective
+> reconstructions** from the commit log, not contemporaneous reporting.
+> Please scan-check each post — Docent is doing archaeology, not
+> remembering what you were actually thinking at the time. Dates are
+> git-authoritative; any force-pushed or rebased history will produce
+> dates that don't reflect when work really happened.
 
 ## Next steps
 

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -30,16 +30,33 @@ gh repo view --json name,description,licenseInfo,primaryLanguage
 
 ### Step 2 — Ask the user for choices
 
-Ask these in ONE message, not sequentially. Provide defaults so the user can
-say "defaults are fine":
+Ask these in ONE message, not sequentially. Provide defaults so the user
+can say "defaults are fine":
 
 1. **Tone** — neutral (default), formal, playful, or technical?
 2. **Journal cadence** — weekly (default), biweekly, monthly, or manual only?
-3. **Custom domain?** — default none; the site will deploy to
+3. **Backfill journal from commit history?** — one of:
+   - **yes, up to 12 posts** (default) — partitions git history into
+     cadence-aligned buckets and writes one dated post per bucket, up
+     to a cap of 12. Oldest buckets collapse into an "Early history"
+     roundup so cost stays bounded on long-history repos.
+   - **yes, custom cap** — user supplies an integer ≥ 2. Minimum of
+     2 because the collapse algorithm needs at least one kept bucket
+     plus a rollup slot.
+   - **no, single welcome post** — `journal.backfill: false` in the
+     generated config. Docent writes one inaugural post spanning the
+     whole history.
+4. **Custom domain?** — default none; the site will deploy to
    `{owner}.github.io/{repo}`.
 
 Do NOT ask about section toggles at init; enable all sections by default.
 Users can disable sections later by editing `docent.config.json`.
+
+Record the user's backfill choice so Step 4's generated
+`docent.config.json` reflects it:
+- "yes, up to 12": `journal.backfill = true`, `journal.backfillLimit = 12`
+- "yes, custom N": `journal.backfill = true`, `journal.backfillLimit = N`
+- "no": `journal.backfill = false`, `journal.backfillLimit = 12` (default retained but unused)
 
 ### Step 3 — Create a working branch
 
@@ -81,8 +98,8 @@ Default contents:
     "cadence": "{{chosen cadence}}",
     "announceReleases": true,
     "minCommitsPerPost": 3,
-    "backfill": true,
-    "backfillLimit": 12
+    "backfill": {{backfill choice true/false from Step 2}},
+    "backfillLimit": {{backfill cap from Step 2, default 12, minimum 2}}
   },
   "status": {
     "groupStrategy": "auto",
@@ -168,8 +185,25 @@ Create `docs/content/` and fill it:
 
 **`docs/content/journal/*.mdx` — backfill posts**
 
-Journal generation branches on `journal.backfill` in config. Default
-is `true` (partition history); `false` writes a single inaugural.
+Journal generation branches on `journal.backfill` in config.
+
+**Runtime fallback rules (important).** JSON Schema `default` fields
+are annotations — most validators do NOT substitute them at parse
+time. So `init` and `update` MUST apply these defaults explicitly
+when reading config:
+
+- If `journal.backfill` is missing → treat as `true`.
+- If `journal.backfillLimit` is missing → treat as `12`.
+- If `journal.backfillLimit` is present and less than 2 → reject
+  the config with a specific error pointing the user at the schema
+  constraint. Do NOT silently clamp; that hides the misconfiguration.
+
+The `backfillLimit: 1` case is rejected specifically because the
+collapse algorithm (step 4 below) keeps `backfillLimit - 1` recent
+buckets and dates the rollup relative to the oldest kept one — with
+zero kept buckets, the rollup has no reference point. Users who want
+a single post should set `backfill: false` (which writes one welcome
+post) rather than `backfillLimit: 1`.
 
 **If `journal.backfill === true`** (default):
 

--- a/skills/docent/schemas/config.schema.json
+++ b/skills/docent/schemas/config.schema.json
@@ -41,7 +41,18 @@
           "enum": ["weekly", "biweekly", "monthly", "manual"]
         },
         "announceReleases": { "type": "boolean" },
-        "minCommitsPerPost": { "type": "integer", "minimum": 0 }
+        "minCommitsPerPost": { "type": "integer", "minimum": 0 },
+        "backfill": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, `init` partitions git history into cadence-aligned buckets and writes one dated post per bucket instead of a single inaugural post. Posts marked `mode: \"backfill\"` are immutable to scheduled runs."
+        },
+        "backfillLimit": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 12,
+          "description": "Maximum number of backfill posts `init` will generate. Caps cost on long-history repos — buckets older than the cap are collapsed into one 'Early history' roundup post."
+        }
       }
     },
     "status": {

--- a/skills/docent/schemas/config.schema.json
+++ b/skills/docent/schemas/config.schema.json
@@ -49,9 +49,9 @@
         },
         "backfillLimit": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 2,
           "default": 12,
-          "description": "Maximum number of backfill posts `init` will generate. Caps cost on long-history repos — buckets older than the cap are collapsed into one 'Early history' roundup post."
+          "description": "Maximum number of backfill posts `init` will generate. Caps cost on long-history repos — buckets older than the cap are collapsed into one 'Early history' roundup post. Minimum is 2 (not 1) because the collapse algorithm keeps `backfillLimit - 1` recent buckets; with a limit of 1, zero recent buckets are kept and the rollup's 'date one second before the oldest kept bucket' rule has no reference point. Users who want only one post should set `backfill: false` instead."
         }
       }
     },


### PR DESCRIPTION
Closes #2.

## Problem

`init` wrote a single inaugural post stamped to today. Repos with months of shipped work arrived with an empty archive and a welcome post — undersold the actual project.

## Fix

### Config

`journal.backfill` (bool, default `true`) toggles the feature. `journal.backfillLimit` (int, default 12) caps cost — essential for long-history repos, because cost scales linearly with bucket count. A 5-year repo on weekly cadence is 260 Claude calls uncapped; with `backfillLimit: 12` it's 13.

### init Step 7

Rewritten algorithm:

1. `git log --reverse --no-merges` walks forward.
2. Commits bucketed by `journal.cadence` (weekly = ISO week; biweekly/monthly; manual = weekly).
3. Drop buckets below `minCommitsPerPost` — no quiet-week filler.
4. Cap at `backfillLimit`. Overflow collapses into one \"Early history\" roundup sorted before the rest.
5. Each kept bucket → one MDX with `mode: \"backfill\"`, `date = last-commit-date`, `commitRange = first-sha..last-sha`.

Posts follow `prompts/journal-system.md`'s **Inaugural and backfill posts** section (added in #5) — retrospective voice, archaeological honesty.

### Init PR body

Lists the generated post filenames and explicitly warns reviewers:

> These are **retrospective reconstructions** from the commit log, not contemporaneous reporting. Please scan-check each post — Docent is doing archaeology, not remembering what you were actually thinking at the time.

### Immutability

SKILL.md gains invariant 8: journal posts are immutable once written, regardless of `mode`. Scheduled runs never rewrite them — `digest` only appends, `update` doesn't touch journal at all. This is how backfill posts stay frozen.

### Live config

`docent.config.json` on this repo now includes `backfill: true, backfillLimit: 12` so the new fields validate.

## Relation to other issues

- #5 added the **Inaugural and backfill posts** prompt guidance; this PR relies on it.
- #4 added `\"backfill\"` to the frontmatter `mode` enum; this PR uses it.
- Expected merge order: #5, then #4, then this — but each stands on its own so any order works with trivial conflict resolution.

## Acceptance

- [x] `docent.config.json` gains `journal.backfill` and `journal.backfillLimit` with defaults
- [x] `modes/init.md` Step 7 emits 1..N journal posts instead of a single inaugural
- [x] Each backfilled post has `mode: \"backfill\"` and a valid `commitRange`
- [x] `update` mode treats `mode: \"backfill\"` files as immutable (via SKILL.md invariant 8 + existing behavior)
- [x] The init PR body lists post filenames and warns reviewers the text is LLM-generated archaeology