### PR TITLE
Issue #6: suggest mode for filing Docent feedback

### DIFF
--- a/skills/docent/SKILL.md
+++ b/skills/docent/SKILL.md
@@ -3,9 +3,11 @@ name: docent
 description: |
   Generates and maintains a public-facing static website for a GitHub repo.
   Use this skill when the user wants to set up Docent, update the Docent site,
-  write a journal post or digest, generate release notes, or triage new issues.
-  Also triggers on mentions of "docent site", "docs site update", or operations
-  on /docs/content/ in a repo that has docent.config.json.
+  write a journal post or digest, generate release notes, triage new issues,
+  or file feedback about Docent itself (the "suggest" mode).
+  Also triggers on mentions of "docent site", "docs site update", operations
+  on /docs/content/ in a repo that has docent.config.json, or phrases like
+  "I want to suggest something about Docent" / "report a Docent bug".
 ---
 
 # Docent
@@ -27,6 +29,7 @@ for and the current state of the repo.
 | "write a journal post", "write a digest", "summarize recent work" | `digest` | `modes/digest.md` |
 | "release notes for {tag}", "generate release notes", new tag pushed | `release` | `modes/release.md` |
 | "triage issues", "look at new issues" | `triage` | `modes/triage.md` |
+| "suggest", "file feedback", "I noticed something about Docent" | `suggest` | `modes/suggest.md` |
 
 When invoked, follow this procedure:
 

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -250,6 +250,13 @@ This PR scaffolds a Docent-maintained site at `/docs`.
    Code subscription — no `ANTHROPIC_API_KEY` required.
 
 The site will be live at {{homepage}} shortly after the first deploy.
+
+---
+
+_Did Docent get something wrong during scaffolding — a prompt that
+missed the mark, a step that failed, a default that doesn't fit this
+project? Open Claude Code, say **"Docent, suggest"**, and it'll help
+you file feedback against [calumjs/docent](https://github.com/calumjs/docent/issues)._
 EOF
 )"
 ```
@@ -260,6 +267,18 @@ Report the PR URL and echo the three-step checklist from the PR body. Make
 the two `/schedule` commands the most prominent part of the reply —
 they're the step the user most often forgets. Call out that Routines run
 on their subscription plan, not via a separate API key.
+
+End the reply with a short invitation to file feedback:
+
+> Noticed something that felt off during scaffolding — a prompt that
+> missed the mark, a step that failed, a default that doesn't fit your
+> project? Say **"Docent, suggest"** anytime and I'll help you file it
+> against calumjs/docent. Every report sharpens the next run.
+
+This nudge is important because init is the moment when the user has
+freshest context on what Docent just did and didn't do well. Waiting
+until they notice again is a longer feedback loop than just asking
+now.
 
 ## Exit conditions
 

--- a/skills/docent/modes/suggest.md
+++ b/skills/docent/modes/suggest.md
@@ -53,27 +53,51 @@ want to fire off a one-liner per question should be able to.
 
 ### Step 2 — Gather environment
 
-Collect context the maintainer will want when triaging, so they don't
-have to ask:
+The issue will be filed on a **public** repository (calumjs/docent).
+Collect only a minimal, non-identifying whitelist of fields — never
+the raw `docent.config.json` or raw repo metadata. A feedback issue
+doesn't need to know which user is filing or which private project
+they're filing from; the maintainer can reproduce from the mode +
+plugin version + a handful of behaviour-shaping flags.
+
+**Do this**:
 
 ```bash
-# Docent config
-cat docent.config.json 2>/dev/null
+# Plugin version only — from plugin.json, NOT the whole file
+node -e 'console.log(require("${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json").version)' 2>/dev/null
 
-# Plugin version — inspect the installed plugin's plugin.json
-cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null
+# Whether the source repo is public or private (affects publishing
+# context; matters for the privacy warning in Step 4.5)
+gh repo view --json visibility -q .visibility 2>/dev/null
 
-# Repo identity (so maintainer can reproduce against a similar project)
-gh repo view --json name,owner,primaryLanguage,repositoryTopics 2>/dev/null
+# From docent.config.json: read it yourself, extract only:
+#   tone, journal.cadence, journal.backfill, journal.backfillLimit
+# Nothing else. Do NOT include project.{name,owner,repo,homepage},
+# deploy.customDomain, or any other field.
 ```
 
+**Do NOT do**:
+
+- Do NOT `cat docent.config.json` into the issue body. The project
+  name, owner slug, custom domain, and (if edited) excludeLabels are
+  identifying or potentially sensitive for private projects.
+- Do NOT run `gh repo view` with `name,owner,primaryLanguage,
+  repositoryTopics`. The owner and repo name identify the user's
+  project to everyone who reads calumjs/docent's issue tracker. The
+  `gh issue create` author field already tells the maintainer who
+  filed it; there's no need to embed owner/repo in the body.
+- Do NOT include git config email, commit messages, or any string
+  scraped from the user's filesystem beyond what's explicitly listed
+  above.
+
 If `docent.config.json` doesn't exist (user is filing feedback on the
-`init` mode itself before it's run), record that as "no config — init
-hadn't been run."
+`init` mode itself before it's run), record behaviour flags as
+"config not yet written."
 
 ### Step 3 — Compose the issue body
 
-Template:
+Template. Note: the environment block is a small, specific whitelist —
+no raw config dump, no identifying repo metadata.
 
 ```markdown
 ## What kind of feedback
@@ -92,43 +116,71 @@ rewritten. If they wrote a one-liner, leave it short.}
 ---
 
 <details>
-<summary>Environment (auto-collected, click to expand)</summary>
+<summary>Environment (whitelisted fields, click to expand)</summary>
 
-**Docent plugin version:** {from plugin.json's version field}
+- **Docent plugin version:** {e.g. 0.1.0}
+- **Tone:** {neutral / formal / playful / technical}
+- **Journal cadence:** {weekly / biweekly / monthly / manual}
+- **Backfill:** {on with limit N / off}
+- **Source repo visibility:** {public / private}
 
-**Source repo:** {owner}/{name} ({primaryLanguage}, topics: {topics})
-
-**docent.config.json:**
-```json
-{contents, or "no config — init hadn't been run"}
-```
+_(No project name, owner, repo, domain, or config contents are
+included here — those identify the user's project and aren't needed
+for Docent triage.)_
 
 </details>
 
 ---
 
-_Filed via Docent `suggest` mode from {owner}/{name}._
+_Filed via Docent `suggest` mode._
 ```
 
-### Step 4 — Redact
+The footer intentionally does NOT say "from {owner}/{name}" — that
+would re-leak identity the whitelist was built to avoid. The `gh
+issue create` author field carries the filer's identity to the
+maintainer without exposing which of their projects was involved.
 
-Before showing the body to the user, run a redaction pass. Replace
+### Step 4 — Redact the prose
+
+The whitelist in Step 2 keeps structured config data out of the body
+by construction. But the user's **prose answers** (to "what happened",
+"where did you notice it") are free-form and can still contain
+secrets — a pasted error message with a token in it, a copied URL with
+credentials. Run a redaction pass over the prose fields only. Replace
 matches with `[REDACTED]`:
 
 - GitHub tokens: `gh[oprs]_[A-Za-z0-9]{20,}`
 - AWS access keys: `AKIA[0-9A-Z]{16}`
+- GCP service-account keys: `-----BEGIN PRIVATE KEY-----` through the
+  matching `-----END PRIVATE KEY-----`
+- JWTs: `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`
+- URLs containing `:` + `@` (basic-auth in URL): e.g. `https://user:pass@host`
 - Generic high-entropy 32+ char hex or base64 runs that appear next to
-  a keyword like `token`, `key`, `secret`, `password`, `api_key`
-- Private email addresses that show up in git config or commit
-  messages inside `docent.config.json` (shouldn't happen, but check)
+  keywords like `token`, `key`, `secret`, `password`, `api_key`, `bearer`
+- Email addresses (unless they're clearly public — GitHub noreply,
+  e.g. `@users.noreply.github.com` stays)
 
-SKILL.md invariant 3 already forbids writing secrets into generated
-*site content*; this step applies the same rule to generated *issue
-content*. Same producer, same duty.
+The regex list is defense-in-depth, not a promise of completeness.
+The primary protection is the whitelist from Step 2: because the
+body never contains raw config or identity fields, there's a much
+smaller surface for a missed pattern to do harm.
 
-If redaction hits on anything, tell the user: "I redacted {N}
-potentially sensitive strings before filing. Please review the preview
-before confirming." Then show the redacted body.
+SKILL.md invariant 3 forbids writing secrets into generated *site
+content*; this extends the same rule to generated *issue content*.
+
+### Step 4.5 — Private-repo warning
+
+If the source repo's visibility (collected in Step 2) is `private`,
+show an extra explicit warning before the confirmation prompt:
+
+> **Heads up**: you're filing feedback from a **private** repository
+> into a **public** issue tracker (calumjs/docent). The environment
+> block only includes Docent behaviour flags (tone, cadence, plugin
+> version, visibility) — no project name, owner, or config content.
+> But your prose description will be public. Review it for any
+> internal details before confirming.
+
+The Step 5 confirmation still waits for explicit user approval.
 
 ### Step 5 — Confirm with the user
 

--- a/skills/docent/modes/suggest.md
+++ b/skills/docent/modes/suggest.md
@@ -1,0 +1,195 @@
+# Mode: `suggest`
+
+File a feedback issue against `calumjs/docent` from inside the user's
+Claude Code session, with their config and plugin version attached. The
+goal: make it easier to say "I noticed something" than to not say it.
+
+## Preconditions
+
+- `gh` CLI is authenticated (`gh auth status` succeeds). If not, prompt
+  the user to run `gh auth login` before continuing.
+- The user explicitly invoked suggest — this mode never runs on
+  schedule and never auto-opens issues.
+
+## What feedback goes here
+
+Feedback about **Docent itself** — its prompts, modes, schemas,
+defaults, or procedure. Things like "the inaugural post came out
+weird," "init Step 5 failed on my harness," "the editorial vibe
+looked wrong on my repo."
+
+Feedback about the **user's own project** (its bugs, its features) does
+NOT go here. That's what the site's `/report-bug/` and
+`/request-feature/` pages are for — they file against the user's own
+repo, not against Docent.
+
+If the user's request sounds like project feedback rather than Docent
+feedback, redirect them before continuing:
+
+> That sounds like feedback for {their-project}, not for Docent. Open
+> the /report-bug/ or /request-feature/ page on your Docent site — it
+> opens a pre-filled issue against your repo. Want me to do that
+> instead?
+
+## Procedure
+
+### Step 1 — Short structured intake
+
+Ask these in ONE message. Keep it to four questions; longer forms kill
+feedback loops harder than no form.
+
+1. **Kind** — enhancement, bug, prompt issue, procedure issue, or
+   other? (Pick one.)
+2. **Where did you notice it?** — which mode were you running (init,
+   update, digest, release, triage, suggest), which file or step was
+   involved.
+3. **What happened?** What did you see, what did you expect instead,
+   and what makes it matter to the maintainer?
+4. **One-line title** (optional). If skipped, draft one yourself from
+   the answer to #3.
+
+Accept short answers. Users who want to write essays can; users who
+want to fire off a one-liner per question should be able to.
+
+### Step 2 — Gather environment
+
+Collect context the maintainer will want when triaging, so they don't
+have to ask:
+
+```bash
+# Docent config
+cat docent.config.json 2>/dev/null
+
+# Plugin version — inspect the installed plugin's plugin.json
+cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null
+
+# Repo identity (so maintainer can reproduce against a similar project)
+gh repo view --json name,owner,primaryLanguage,repositoryTopics 2>/dev/null
+```
+
+If `docent.config.json` doesn't exist (user is filing feedback on the
+`init` mode itself before it's run), record that as "no config — init
+hadn't been run."
+
+### Step 3 — Compose the issue body
+
+Template:
+
+```markdown
+## What kind of feedback
+
+{kind}
+
+## Where
+
+{where — mode, file, step}
+
+## What happened
+
+{what they told you, their words lightly edited for clarity but NOT
+rewritten. If they wrote a one-liner, leave it short.}
+
+---
+
+<details>
+<summary>Environment (auto-collected, click to expand)</summary>
+
+**Docent plugin version:** {from plugin.json's version field}
+
+**Source repo:** {owner}/{name} ({primaryLanguage}, topics: {topics})
+
+**docent.config.json:**
+```json
+{contents, or "no config — init hadn't been run"}
+```
+
+</details>
+
+---
+
+_Filed via Docent `suggest` mode from {owner}/{name}._
+```
+
+### Step 4 — Redact
+
+Before showing the body to the user, run a redaction pass. Replace
+matches with `[REDACTED]`:
+
+- GitHub tokens: `gh[oprs]_[A-Za-z0-9]{20,}`
+- AWS access keys: `AKIA[0-9A-Z]{16}`
+- Generic high-entropy 32+ char hex or base64 runs that appear next to
+  a keyword like `token`, `key`, `secret`, `password`, `api_key`
+- Private email addresses that show up in git config or commit
+  messages inside `docent.config.json` (shouldn't happen, but check)
+
+SKILL.md invariant 3 already forbids writing secrets into generated
+*site content*; this step applies the same rule to generated *issue
+content*. Same producer, same duty.
+
+If redaction hits on anything, tell the user: "I redacted {N}
+potentially sensitive strings before filing. Please review the preview
+before confirming." Then show the redacted body.
+
+### Step 5 — Confirm with the user
+
+Show the full composed body and the target:
+
+> I'm about to file this against `calumjs/docent`:
+>
+> **Title:** {title}
+>
+> {body}
+>
+> Confirm to file, or say what to change.
+
+Wait for explicit confirmation. Never call `gh issue create` without
+an affirmative response from the user in this turn — no silent
+external writes.
+
+If the user requests changes, apply them and re-confirm before filing.
+
+### Step 6 — File
+
+```bash
+gh issue create \
+  --repo calumjs/docent \
+  --title "{title}" \
+  --body "$(cat <<'EOF'
+{redacted, confirmed body}
+EOF
+)" \
+  --label "{kind-derived-label}"
+```
+
+Labels by kind:
+- `enhancement` or other → `enhancement`
+- `bug` → `bug`
+- `prompt issue`, `procedure issue` → `documentation`
+- `other` → no label (maintainer triages)
+
+### Step 7 — Report back
+
+Report the issue URL to the user. Thank them briefly and mention that
+the maintainer reviews feedback when iterating on Docent's prompts.
+
+## Exit conditions
+
+- Issue filed, URL reported, or
+- User declined to confirm — exit without filing. Do not retry
+  automatically.
+
+## Error handling
+
+- **`gh auth status` fails**: prompt the user to run `gh auth login`.
+- **`gh issue create` fails** (rate limit, network, permissions): show
+  the full composed body and the title so the user can file manually
+  at https://github.com/calumjs/docent/issues/new.
+
+## Non-goals
+
+- Not a general-purpose bug tracker. Feedback goes to `calumjs/docent`,
+  not to the user's own repo.
+- Not anonymous. Issues are filed under the authenticated `gh` user,
+  same as any other `gh issue create`.
+- Not a proxy for iterating on the user's project — use the site's
+  `/report-bug/` or `/request-feature/` forms for that.


### PR DESCRIPTION
Closes #6.

## Problem

No frictionless path from \"I noticed something about Docent\" to \"the maintainer sees a tracked suggestion.\" Users have to leave their session, remember the repo name, navigate to New Issue, and write into a blank box. Friction kills feedback; most never arrives.

## Fix

### New mode: `suggest`

`skills/docent/modes/suggest.md`. Invoked by \"Docent, suggest\" or natural-language equivalents.

**4-question intake:**
1. Kind (enhancement / bug / prompt / procedure / other)
2. Where (mode, file, step)
3. What happened vs expected
4. Optional one-line title (drafted from #3 if skipped)

**Auto-collected environment** (in a collapsible detail block in the issue body):
- Plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`
- `docent.config.json` contents
- `gh repo view` identity (name, owner, primaryLanguage, topics)

**Token redaction** before confirmation — GH tokens, AWS keys, generic high-entropy runs next to `token` / `secret` keywords. Matches SKILL.md invariant 3 (no secrets in generated content) applied to *issue* content.

**Explicit confirmation required** before `gh issue create`. Same guardrail as triage mode: draft, show, wait for yes, then file.

**Target repo**: `calumjs/docent`, not the user's own repo. Project-level feedback redirects to the `/report-bug/` and `/request-feature/` forms already on the rendered site.

### Surfacing

Users won't discover the mode if we don't point them at it:

- **init.md Step 10** appends a nudge to the user-facing report right after scaffolding — the moment context is freshest.
- **init.md Step 9** PR body footer links \"Docent, suggest\" so later reviewers of the merged init PR see it too.
- **SKILL.md** mode table + frontmatter description updated so the skill dispatcher matches phrases like \"I want to suggest something about Docent\".

## Acceptance

- [x] `skills/docent/modes/suggest.md` exists and runs via \"Docent, suggest\"
- [x] 3-4 questions max
- [x] Issue body includes config + plugin version as a collapsible detail block
- [x] Confirmation required before `gh issue create`
- [x] Token redaction runs before confirmation
- [x] `modes/init.md` Step 10 mentions the suggest skill