### PR TITLE
Docent: merge update + digest into one adaptive daily routine

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A Claude skill that turns a GitHub repo into a public-facing, self-maintaining website.",
   "homepage": "https://github.com/calumjs/docent",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ After merging the PR, two manual steps only you can do:
    ```
    (Or via the web UI: **Settings → Pages → Source → GitHub Actions**.)
 
-2. **Set up the two Routines** that keep content fresh:
+2. **Set up the Routine** that keeps content fresh:
    ```
-   /schedule update Docent daily at 10:17 — prompt: "Docent: run update mode."
-   /schedule digest Docent weekly on Mondays at 9:17 — prompt: "Docent: run digest mode."
+   /schedule Docent update daily at 08:00 — prompt: "Docent: run update mode."
    ```
-   Routines use your Claude Code subscription tokens — no `ANTHROPIC_API_KEY` required.
+   One routine, adaptive output: update mode decides for itself whether to refresh content, write a journal post, both, or nothing — based on what's happened in the repo since the last run. Routines use your Claude Code subscription tokens — no `ANTHROPIC_API_KEY` required.
 
 You can also invoke Docent manually anytime: **"Docent, write a journal post about the auth refactor."**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -552,7 +552,8 @@ different mechanisms:
 | Build and deploy the Astro site to GitHub Pages | GitHub Actions | Pure static build, no Claude in the loop; native to Pages |
 
 A Docent install ends up with one GitHub Actions file (`docent-deploy.yml`)
-and two Routines (`docent-update` and `docent-digest`).
+and one Routine (`docent-update`). The update routine decides for itself
+whether a given day's activity warrants a journal post.
 
 ### 6.1 Why Routines, not GitHub Actions, for content
 
@@ -569,8 +570,8 @@ Limitations the design has to live with:
 - **Cron-only, no webhooks.** Routines can't fire on GitHub issue events
   directly. The `update` routine polls daily; the tradeoff is a
   status page that lags by up to a day instead of updating within minutes.
-- **Daily run-count cap** on Claude Code plans. Two routines per repo is
-  well under typical caps even for small plans.
+- **Daily run-count cap** on Claude Code plans. One routine per repo
+  is well under typical caps even on small plans.
 - **Creation is UI/CLI, not programmatic.** The skill can't call a tool to
   create routines. `init` mode outputs the exact `/schedule` commands for
   the user to run manually.
@@ -580,46 +581,45 @@ Limitations the design has to live with:
 At the end of `init` mode, the skill prints:
 
 ```
-Docent is installed. To finish setup, run these two commands in Claude Code:
+Docent is installed. To finish setup, run one command in Claude Code:
 
-  /schedule update Docent daily at 10:17 — prompt: "Docent: run update mode."
-  /schedule digest Docent weekly on Mondays at 9:17 — prompt: "Docent: run digest mode."
+  /schedule Docent update daily at 08:00 — prompt: "Docent: run update mode."
 
-Or configure them in the Claude Code UI at claude.ai/code/routines.
+Or configure it in the Claude Code UI at claude.ai/code/routines.
 ```
 
 Times use off-minute values (`:17`) to avoid the thundering-herd cost of
 everyone's routines firing at `:00`. See `prompts/tone-presets.md` for the
 analogous principle applied to content.
 
-### 6.3 Update routine
+### 6.3 The update routine (one mode, adaptive output)
 
-- **Cadence**: daily, ~10:17 local.
+- **Cadence**: daily, ~08:00 local.
 - **Prompt**: `Docent: run update mode.`
-- **What it does**: follows `modes/update.md` — regenerates `status.json`
-  from current issues, refreshes `overview.mdx` if `README.md` changed or
-  the file is >90 days old, and runs `release` mode for any tag newer than
-  the most recent changelog entry. Opens a PR if anything changed,
-  otherwise exits silently (the idempotency invariant).
+- **What it does**: follows `modes/update.md`. On each run:
+  1. Checks `status.json` / `overview.mdx` / `changelog.mdx` anchors
+     and regenerates whichever drifted (respecting hand-edit
+     detection).
+  2. Decides whether the period's activity (merged PRs, closed issues,
+     commits since the last journal post) warrants a journal post.
+     The decision is LLM-driven — rough guidance in `update.md` Step 6
+     but ultimately agent judgment. "Honest silence beats padded prose."
+  3. If anything was regenerated OR a journal post was written, opens
+     one combined PR. If nothing, exits silently.
 
-Daily is cheap because most days produce no PR. The routine fetches
-issues, hashes the result against the prior `status.json`, and bails early
-if identical.
+The daily cadence combined with adaptive output replaces the earlier
+two-routine design (daily update + weekly Monday digest). Rationale:
 
-### 6.4 Digest routine
+- Weekly cadence created a "silence until Monday" gap on active repos.
+- A fixed schedule produced posts on quiet weeks and missed stories on
+  active days that weren't Monday.
+- Users had to set up and remember two routines.
 
-- **Cadence**: weekly, Mondays ~09:17 local.
-- **Prompt**: `Docent: run digest mode.`
-- **What it does**: follows `modes/digest.md` — finds the time window
-  since the last journal post, gathers merged PRs and closed issues,
-  identifies themes, writes one post, opens a PR.
+One daily routine with discretion solves all three. Users who want
+topic-scoped posts on demand still have `digest` mode (manually
+invoked — no schedule).
 
-The weekly cron is fixed; the **effective cadence** is controlled by
-`journal.cadence` in `docent.config.json`. If set to `biweekly` or
-`monthly`, `digest` mode's time-window check causes off-week runs to exit
-silently. Users change cadence by editing config, not the routine.
-
-### 6.5 `docent-deploy.yml` (the one GitHub Actions file)
+### 6.4 `docent-deploy.yml` (the one GitHub Actions file)
 
 Deploys the site to GitHub Pages on pushes to main that touch `/docs` or
 the config. This is a pure static build — Claude is not involved.
@@ -663,7 +663,7 @@ Uses the modern official-action flow: `configure-pages` +
 `upload-pages-artifact` + `deploy-pages`. Requires **Settings → Pages →
 Source: GitHub Actions** to be enabled (one-time manual step).
 
-### 6.6 Local dev mode
+### 6.5 Local dev mode
 
 While iterating on the skill itself, the Routine feedback loop is too slow
 — you want to fire the skill against a repo and see results in seconds,
@@ -677,7 +677,7 @@ not wait a day. Use either:
 Neither is a substitute for Routines in production — both require an
 active Claude Code session and both auto-expire.
 
-### 6.7 Appendix: GitHub Actions fallback for content
+### 6.6 Appendix: GitHub Actions fallback for content
 
 Users who prefer CI over Routines (e.g. organizations with strict
 policies about hosted AI runners, or users not on a Claude Code plan) can
@@ -780,8 +780,8 @@ The PR the skill opens includes a checklist in its description:
 > 2. **Merge this PR.** The deploy workflow runs automatically.
 > 3. **Set up the Routines** that keep content fresh. In Claude Code, run:
 >    ```
->    /schedule update Docent daily at 10:17 — prompt: "Docent: run update mode."
->    /schedule digest Docent weekly on Mondays at 9:17 — prompt: "Docent: run digest mode."
+>    /schedule update Docent daily at 08:00 — prompt: "Docent: run update mode."
+>    /schedule digest Docent weekly on Mondays at 08:00 — prompt: "Docent: run digest mode."
 >    ```
 >    Or configure them at claude.ai/code/routines.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,7 +21,7 @@ live at [calumjs.github.io/docent](https://calumjs.github.io/docent/).
 - [x] `skills/docent/templates/workflows/docent-deploy.yml` —
       Pages deploy (primary path)
 - [x] `skills/docent/templates/workflows/docent-update.yml` and
-      `docent-digest.yml` — optional CI fallbacks (SPEC §6.7)
+      `docent-digest.yml` — optional CI fallbacks (SPEC §6.6)
 - [x] SPEC §6 rewritten around Claude Code Routines as the primary
       scheduler; GitHub Actions reduced to the Pages deploy
 - [x] **Plugin-marketplace packaging** (SPEC §7.1): `.claude-plugin/`

--- a/skills/docent/modes/digest.md
+++ b/skills/docent/modes/digest.md
@@ -1,12 +1,23 @@
 # Mode: `digest`
 
-Write a journal post summarizing recent repository activity. Triggered by
-scheduled runs (if cadence matches) or by the user asking for a digest.
+Write a journal post summarizing recent repository activity.
+
+**Manual invocation only.** The scheduled daily Routine uses `update`
+mode, which decides for itself whether to write a post based on window
+activity (see `update.md` Step 6). `digest` is for when a user
+explicitly asks ("Docent, write a post about the auth refactor,"
+"Docent, digest the last month") — scoped to a specific topic or time
+window the user specifies.
+
+A digest invocation bypasses the update-mode's "is this journal-worthy"
+check. The user asked for a post, so write one — even if the activity
+bar wouldn't clear on its own.
 
 ## Preconditions
 
 - `docent.config.json` exists and `sections.journal` is `true`.
 - `/docs/content/journal/` exists.
+- User explicitly invoked this mode (not scheduled).
 
 ## Procedure
 

--- a/skills/docent/modes/init.md
+++ b/skills/docent/modes/init.md
@@ -158,7 +158,7 @@ the repo's default branch (detected in Step 1) is something else (e.g.
 `templates/workflows/`.
 
 Do NOT copy `docent-update.yml` or `docent-digest.yml` — those are
-optional CI fallbacks (§6.7) for users who can't or won't use Routines.
+optional CI fallbacks (§6.6) for users who can't or won't use Routines.
 Users opt in by copying them manually later.
 
 ### Step 7 — Generate initial content
@@ -401,18 +401,21 @@ This PR scaffolds a Docent-maintained site at `/docs`.
      gh api -X POST repos/{{owner}}/{{repo}}/pages -f build_type=workflow
      ```
 2. **Merge this PR.** The deploy workflow runs automatically.
-3. **Set up the Routines** that keep content fresh. In any Claude Code
-   session, run these two commands. Each spawns a remote environment
-   that starts with *nothing installed* — the prompts must bootstrap
-   the Docent plugin before dispatching to the mode:
+3. **Set up the Routine** that keeps content fresh. In any Claude Code
+   session, run one command. The routine spawns a remote environment
+   that starts with *nothing installed* — the prompt must bootstrap
+   the Docent plugin before dispatching to update mode:
 
    ```
-   /schedule Docent update daily at 10:17 — If the Docent skill is not available in this environment, run `/plugin marketplace add calumjs/docent` and `/plugin install docent@docent` first. Then follow skills/docent/modes/update.md against the current repo.
+   /schedule Docent update daily at 08:00 — If the Docent skill is not available in this environment, run `/plugin marketplace add calumjs/docent` and `/plugin install docent@docent` first. Then follow skills/docent/modes/update.md against the current repo.
    ```
 
-   ```
-   /schedule Docent digest weekly on Mondays at 9:17 — If the Docent skill is not available in this environment, run `/plugin marketplace add calumjs/docent` and `/plugin install docent@docent` first. Then follow skills/docent/modes/digest.md against the current repo.
-   ```
+   One routine, adaptive output: update mode decides for itself whether
+   to regenerate content, write a journal post, both, or nothing,
+   based on what happened since the last run (`modes/update.md` Step 6).
+   The digest mode is still available for manual invocation ("Docent,
+   write a post about the auth refactor") but has no scheduled
+   presence.
 
    The bootstrap clause is there because Claude Code Routines run in a
    clean remote CCR environment that does NOT inherit plugins from the
@@ -435,10 +438,10 @@ This PR scaffolds a Docent-maintained site at `/docs`.
 
    **DST caveat.** Claude Code Routines take UTC cron only; they do
    not currently support IANA-timezone-aware scheduling. A routine
-   scheduled for "10:17 Sydney" becomes a fixed UTC cron that drifts
+   scheduled for "08:00 Sydney" becomes a fixed UTC cron that drifts
    by an hour when Australia enters or leaves AEDT. For most content
    workflows this doesn't matter (who cares if the daily update runs
-   at 09:17 vs 10:17?), but users who need wall-clock-stable timing
+   at 008:00 vs 08:00?), but users who need wall-clock-stable timing
    should plan to re-adjust the cron twice yearly at DST transitions,
    or pick a local time far from midnight where an hour's drift is
    inconsequential.
@@ -458,42 +461,40 @@ EOF
 ### Step 10 — Report back to the user
 
 Report the PR URL and echo the three-step checklist from the PR body.
-Make the two routine-creation commands the most prominent part of the
-reply — they're the step the user most often forgets. Call out that
-Routines run on their subscription plan, not via a separate API key.
+Make the routine-creation command the most prominent part of the
+reply — it's the step users most often forget. Call out that Routines
+run on their subscription plan, not via a separate API key.
 
-**Offer to create the routines directly.** At the end of the report,
-ask whether the user wants you to set up the two routines now. If they
-agree, invoke the `schedule` skill (via the Skill tool) with the two
-routine definitions below. This saves the user from pasting the long
-bootstrap prompts manually.
+**Offer to create the routine directly.** At the end of the report,
+ask whether the user wants you to set up the update routine now. If
+they agree, invoke the `schedule` skill (via the Skill tool) with the
+routine definition below. This saves the user from pasting the long
+bootstrap prompt manually.
 
-The two routine definitions to pass:
+The routine definition to pass:
 
-1. Name: `Docent update`. Cron: daily at 10:17 local (convert to UTC
-   for the cron expression based on the user's timezone). Prompt:
-   ```
-   If the Docent skill is not available in this environment, run:
-     /plugin marketplace add calumjs/docent
-     /plugin install docent@docent
-   Then follow skills/docent/modes/update.md against this repo. Open
-   a PR against the default branch if anything changed.
-   ```
+- Name: `Docent update`. Cron: daily at 08:00 local (convert to UTC
+  for the cron expression based on the user's timezone). Prompt:
+  ```
+  If the Docent skill is not available in this environment, run:
+    /plugin marketplace add calumjs/docent
+    /plugin install docent@docent
+  Then follow skills/docent/modes/update.md against this repo. Update
+  mode will decide for itself whether the day's activity is worth a
+  journal post; if it is, write one in the same PR. Open a PR against
+  the default branch if anything changed, otherwise exit silently.
+  ```
 
-2. Name: `Docent digest`. Cron: Mondays at 9:17 local (convert to UTC).
-   Prompt:
-   ```
-   If the Docent skill is not available in this environment, run:
-     /plugin marketplace add calumjs/docent
-     /plugin install docent@docent
-   Then follow skills/docent/modes/digest.md against this repo. Open
-   a PR against the default branch with the new journal post.
-   ```
-
-Both routines target the user's GitHub repo (owner/repo already
+The routine targets the user's GitHub repo (owner/repo already
 collected in Step 1). If the user declines the offer or the schedule
-skill isn't available, fall back to printing the paste-these commands
+skill isn't available, fall back to printing the paste-this command
 from Step 9's PR body.
+
+**No separate digest routine.** Earlier versions of this skill shipped
+two Routines (daily update + weekly digest). That's consolidated now:
+update mode decides journal-worthiness adaptively. Manual digest
+invocation ("Docent, write a post about X") still works via
+`modes/digest.md` for topic-scoped posts.
 
 End the reply with a short invitation to file feedback:
 

--- a/skills/docent/modes/update.md
+++ b/skills/docent/modes/update.md
@@ -1,8 +1,30 @@
 # Mode: `update`
 
-Refresh status, overview, and changelog when their sources have changed.
-Runs on a schedule (typically daily) or when the user says "update
-Docent" / "refresh the site."
+The daily routine. Refreshes status / overview / changelog when their
+sources have changed, and — on days where enough interesting activity
+has landed — also writes a new journal post summarizing the period.
+One mode, one Routine, adaptive output.
+
+Runs on a daily schedule, or when the user says "update Docent" /
+"refresh the site."
+
+## Outputs at a glance
+
+Depending on what's happened since the last run, one update can produce:
+
+1. **Nothing.** No anchors drifted and no journal-worthy activity → no
+   PR, silent exit (honors SKILL.md invariant 5 idempotency).
+2. **Content refresh only.** Status/overview/changelog anchors drifted
+   but recent activity isn't substantial enough for a journal post →
+   one PR with the stale content regenerated.
+3. **Content refresh + journal post.** Anchors drifted AND enough has
+   happened to tell a story → one PR combining both.
+4. **Journal post only** (rare). Anchors fresh but a lot has shipped
+   (e.g., all in the same day, all touching things unrelated to
+   README / issues / tags) → one PR with just the new journal post.
+
+Journal posts never overwrite existing posts; they always append.
+Existing posts are immutable (SKILL.md invariant 8).
 
 ## Preconditions
 
@@ -174,29 +196,119 @@ writing. This records the commit Docent reconciled against; a future
 run comparing `sourceCommit` to HEAD is a cheap first-pass check
 before doing the expensive tag-set diff.
 
-### Step 6 — If nothing changed, exit
+### Step 6 — Decide whether to write a journal post
+
+Journal posts land on days when something worth reading about has
+happened, not on a fixed cadence. Use judgment — the thresholds below
+are suggestions, not rules.
+
+**Gather the window.**
+
+Find the most recent `docs/content/journal/*.mdx` post. Its frontmatter
+`commitRange` ends at some SHA; the window is from there to current
+`HEAD`. If no prior posts exist, use the most recent 7 days of commits.
+
+```bash
+# Newest journal post (filename is ISO-dated, so `ls -r` is chronological)
+ls -r docs/content/journal/*.mdx | head -1
+
+# Activity in the window
+gh pr list --state merged --search "merged:>{start-date}" --limit 50 \
+  --json number,title,body,labels,mergedAt,author
+
+gh issue list --state closed --search "closed:>{start-date}" --limit 50 \
+  --json number,title,labels,closedAt
+
+git log {start-ref}..HEAD --no-merges --format='%h|%an|%s'
+
+git tag --contains {start-ref} --sort=creatordate
+```
+
+**Decide whether to post.**
+
+Rough guidance (adjust based on the shape of the project — a repo that
+ships one PR a quarter vs. one a day has very different "interesting"
+bars):
+
+- **Likely post**: ≥ 3 merged PRs OR ≥ 10 non-merge commits in the
+  window, AND the window spans at least ~2 days of activity.
+- **Likely skip**: < 3 merged PRs AND < 10 commits, OR everything is
+  purely internal (dependency bumps, whitespace, one-char typo fixes),
+  OR the last journal post was less than 2 days ago.
+- **Definitely post**: a new release tag appeared in the window (covered
+  separately by `release` mode's announce flag, but still — a tagged
+  release always deserves at least a mention).
+- **Definitely skip**: nothing merged, nothing closed, no tags, fewer
+  than 3 meaningful commits.
+
+These are *suggestions*. Ultimately: if you can write a post with 2–5
+coherent themes that a non-contributor would find worth reading, write
+it. If the best you can manage is "some small fixes shipped," skip.
+Honest silence beats padded prose.
+
+**Also consider cadence.** If the last post was yesterday, raise the
+bar significantly — an active project shouldn't produce daily journal
+posts. "≥ 2 days since the last post" is a soft floor unless something
+genuinely large landed in the last 24h (big release, major refactor,
+significant incident).
+
+**If the decision is skip**, skip Step 6's write — the update still
+proceeds with whatever content regeneration it found. If the decision
+is post, continue.
+
+**Write the post.**
+
+Follow `prompts/journal-system.md` for voice and structure. Filename:
+`docs/content/journal/{YYYY-MM-DD}-{slug}.mdx`. Frontmatter:
+
+```yaml
+---
+title: "Specific headline"
+date: "{YYYY-MM-DD}"
+summary: "One-sentence subtitle."
+tags: ["daily"]                    # or topic-specific tags
+generatedBy: "docent"
+generatedAt: "{ISO timestamp}"
+mode: "digest"
+commitRange: "{start-sha}..{HEAD-sha}"
+bodyHash: "{computed per init.md's bodyHash procedure}"
+---
+```
+
+Use `mode: "digest"` for posts written this way — preserves continuity
+with the (now manually-invoked) digest mode's output shape, and the
+journal index template treats both identically.
+
+Include the new post in the same update PR as any content refresh.
+
+### Step 7 — If nothing changed, exit
 
 If `status.json`, `overview.mdx`, and `changelog.mdx` were all left
-alone, do nothing. Report "Docent: nothing to update" and exit without
-opening a PR. This honors SKILL.md invariant 5 (idempotency).
+alone AND no journal post was written, do nothing. Report "Docent:
+nothing to update" and exit without opening a PR. This honors SKILL.md
+invariant 5 (idempotency).
 
 Running `update` immediately after `init` on an unchanged repo MUST be
 a no-op PR-wise. The anchors are the mechanism.
 
-### Step 7 — Otherwise, commit and open PR
+### Step 8 — Otherwise, commit and open PR
 
 Branch: `docent/update-$(date -u +%Y-%m-%d)`.
 
-PR title: `Docent: update {YYYY-MM-DD}`.
+PR title: one of:
+- `Docent: update {YYYY-MM-DD}` — content refresh only
+- `Docent: journal post — {headline}` — journal post only
+- `Docent: update + journal post — {headline}` — both
 
-PR body: bullet list of what changed and why (which anchor drifted).
+PR body: bullet list of what changed and why (which anchor drifted,
+whether a journal post was added and on what basis).
 
 ```bash
 git checkout -b docent/update-$(date -u +%Y-%m-%d)
 git add docs/content/
-git commit -m "Docent: update status and content"
+git commit -m "Docent: {update|journal post|update + journal post}"
 git push -u origin HEAD
-gh pr create --title "Docent: update $(date -u +%Y-%m-%d)" --body "..."
+gh pr create --title "..." --body "..."
 ```
 
 The `Docent:` commit-subject prefix is load-bearing — Step 2's
@@ -206,8 +318,8 @@ prefix.
 
 ## Exit conditions
 
-- PR opened with the content changes that were actually stale, or
-- No-op reported if everything was fresh.
+- PR opened containing any combination of content refresh + journal post, or
+- No-op reported if everything was fresh AND no journal post was warranted.
 
 ## Never write to theme.json
 


### PR DESCRIPTION
## Why

Today's dogfood found the gap: merged 6 PRs, site had 1 inaugural post. The digest routine is scheduled Mondays, so there was a ~7-day silence even on a genuinely active launch day.

Fixed schedules are the wrong abstraction for this. Journal posts should land when something happened, not because it's Monday.

## What changed

### One routine, adaptive output

Update mode is now daily and decides for itself what to do:

- **Nothing changed** → no-op, no PR
- **Anchors drifted** → content refresh PR
- **Journal-worthy activity** → journal post PR
- **Both** → one combined PR

Decision lives in new `update.md` Step 6 with prompt-level guidance (~3 merged PRs or ~10 commits, ≥ 2 days since last post) framed as suggestions, not thresholds. Final call is agent judgment — "honest silence beats padded prose."

### Digest mode stays, but manual-only

`digest.md` reframed for user-invoked topic-scoped posts (\"Docent, write a post about X\"). No longer has a scheduled presence. The two-routine shape is gone from init's output and SPEC §6.

### Time change

Cron moved from `:17` off-minutes to `08:00` local, per your preference. Live routine's cron updated to `0 22 * * *` (UTC for Sydney AEST). Small loss of thundering-herd avoidance; small win in user-facing copy.

### Live routines also updated

- update routine got the combined prompt + new cron
- digest routine set to `enabled: false` (API doesn't support delete)

## Files touched

- `skills/docent/modes/update.md` — Step 6 added, Steps 7/8 renumbered, header rewritten
- `skills/docent/modes/digest.md` — reframed as manual-invocation
- `skills/docent/modes/init.md` — one routine in Step 9/10, not two
- `README.md` — install instructions collapsed
- `SPEC.md` §6 — consolidation rationale, sections renumbered (6.4-6.7 → 6.3-6.6)
- `STATUS.md` — SPEC §6.7 → §6.6 reference